### PR TITLE
Add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Contributions are welcome! This plugin is part of the [Attest Protocol](https://github.com/attest-protocol) ecosystem.
+
+## Reporting Issues
+
+Open a GitHub issue for:
+
+- Bugs in receipt generation or chain integrity
+- Incorrect taxonomy mappings
+- Missing OpenClaw tool classifications
+- Documentation gaps
+
+## Development Setup
+
+```bash
+git clone https://github.com/attest-protocol/openclaw-attest.git
+cd openclaw-attest
+pnpm install
+```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `pnpm test` | Run test suite |
+| `pnpm test:coverage` | Run tests with coverage |
+| `pnpm run typecheck` | TypeScript type checking |
+
+## Development Process
+
+1. Fork the repo and create a branch from `main`
+2. Follow the existing code conventions
+3. Run `pnpm run typecheck` and `pnpm test`
+4. Open a pull request
+
+## Code Conventions
+
+- TypeScript ESM with strict mode
+- Use `import type` for type-only imports
+- Test files as colocated `*.test.ts` in `src/`
+- Vitest for all tests; cover edge cases
+- Never push directly to `main`
+
+## Taxonomy Contributions
+
+Adding mappings for new OpenClaw tools is a great way to contribute. Edit `taxonomy.json` and add corresponding tests in `src/classify.test.ts`.
+
+## Spec Alignment
+
+This plugin implements the [Action Receipt Protocol](https://github.com/attest-protocol/spec) via the `@attest-protocol/attest-ts` SDK. Changes must remain compatible with the protocol specification.
+
+## License
+
+MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | Yes       |
+
+## Reporting a Vulnerability
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please use one of:
+
+- GitHub's **Report a vulnerability** feature on this repository
+- Email: otto@0tt0.net
+
+Include as much detail as possible: description, steps to reproduce, impact assessment, and any suggested fix.
+
+## Scope
+
+Security reports for this plugin cover:
+
+- Receipt signature forgery or bypass
+- Hash chain integrity violations
+- Key material leakage (private keys exposed via logs, tools, or store)
+- Injection attacks through tool parameters or taxonomy config
+- Privilege escalation through the plugin's OpenClaw hooks
+
+Issues in the underlying `@attest-protocol/attest-ts` SDK should be reported to the [attest-ts repository](https://github.com/attest-protocol/attest-ts/security).
+
+## Disclosure Policy
+
+- Reports are triaged within 48 hours
+- Fixes are coordinated with the reporter before public disclosure
+- Reporters are credited in release notes unless they prefer anonymity


### PR DESCRIPTION
## Summary
- Add security policy (vulnerability reporting scope and disclosure process)
- Add contributing guide (dev setup, conventions, taxonomy contributions)
- Both follow attest-protocol org conventions

## Test plan
- No code changes; docs only