### PR TITLE
Fix package metadata, add LICENSE, harden .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 dist/
 *.db
+*.tgz
 package-lock.json
+keys.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ pnpm install
 
 | Command | Description |
 |---------|-------------|
+| `pnpm run build` | Compile TypeScript to dist/ |
 | `pnpm test` | Run test suite |
 | `pnpm test:coverage` | Run tests with coverage |
 | `pnpm run typecheck` | TypeScript type checking |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Attest Protocol Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Cryptographically signed, hash-linked audit trail for every tool call an OpenClaw agent makes.
 
-Built on [`@attest-protocol/attest-ts`](https://github.com/attest-protocol/attest-ts) — zero runtime dependencies beyond the SDK.
+Built on [`@attest-protocol/attest-ts`](https://github.com/attest-protocol/attest-ts) and [`@sinclair/typebox`](https://github.com/sinclairzx81/typebox).
 
 [Spec](https://github.com/attest-protocol/spec) &bull; [TypeScript SDK](https://github.com/attest-protocol/attest-ts) &bull; [Python SDK](https://github.com/attest-protocol/attest-py)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,33 @@
   "version": "0.1.0",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Attest Protocol",
   "type": "module",
+  "license": "MIT",
+  "author": "Otto Jongerius",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/attest-protocol/openclaw-attest.git"
+  },
+  "keywords": [
+    "openclaw",
+    "attest-protocol",
+    "audit-trail",
+    "receipts",
+    "verifiable-credentials",
+    "ed25519"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "taxonomy.json",
+    "openclaw.plugin.json"
+  ],
   "scripts": {
+    "build": "tsc",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary

Fixes from code review — nitpick and consistency items addressed directly:

- **package.json**: Add missing `license`, `author`, `repository`, `keywords`, `exports`, `files`, and `build` script fields needed for npm publish
- **LICENSE**: Add MIT license file (README badge linked to it but it didn't exist)
- **.gitignore**: Add `keys.json` (prevent committing private keys) and `*.tgz` (pack artifacts)
- **README.md**: Fix inaccurate "zero runtime deps" claim — `@sinclair/typebox` is also a runtime dep
- **CONTRIBUTING.md**: Add `pnpm run build` to dev commands table

## Related issues (opened for hardening items)

- #16 — Pending call stash memory leak in hooks.ts
- #17 — Module-level mutable state prevents multi-instance use
- #18 — Unsafe type casts in tools.ts query parameters
- #19 — Private key file written with world-readable permissions
- #20 — Add tests for loadCustomMappings and custom taxonomy path

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm test` — all 45 tests pass
- [x] No functional code changes — metadata, docs, and gitignore only