### PR TITLE
Add integration smoke test for full plugin lifecycle

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -78,8 +78,14 @@ async function fireHook(
 
 describe("integration: full plugin lifecycle", () => {
   let tempDir: string;
+  let teardown: (() => Promise<void>) | undefined;
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Close the store before removing temp files to avoid leaked file handles
+    if (teardown) {
+      await teardown();
+      teardown = undefined;
+    }
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -97,6 +103,14 @@ describe("integration: full plugin lifecycle", () => {
 
     const mock = createMockApi(config);
     plugin.register(mock.api);
+
+    // Wire up teardown so afterEach always closes the store
+    teardown = async () => {
+      for (const svc of mock.services) {
+        await svc.stop?.();
+      }
+    };
+
     return mock;
   }
 
@@ -183,8 +197,7 @@ describe("integration: full plugin lifecycle", () => {
       expect(r.sequence_valid).toBe(true);
     }
 
-    // 5. Shutdown service
-    await services[0].stop!();
+    // 5. Shutdown is handled by afterEach teardown
   });
 
   it("session reset clears chain state", async () => {


### PR DESCRIPTION
## Summary

Adds an integration test that exercises the **exact same code path OpenClaw uses at runtime** — builds a mock `OpenClawPluginApi`, calls `register()`, then drives the complete lifecycle through the captured hooks and tools.

This is the one thing our 55 unit tests didn't cover: the wiring in `index.ts register()` that connects config → keys → store → hooks → tools → service shutdown.

### Test scenarios (5 tests)

1. **Registration** — verify hooks, tools, and service are wired correctly
2. **Full lifecycle** — session_start → 3 tool calls (read/write/delete) → query receipts → verify chain → shutdown. Checks action types, risk levels, sequence numbers, signatures, and hash links.
3. **Session reset** — two independent sessions with separate chains, verify both are valid and sequence numbers restart
4. **Disabled plugin** — `enabled: false` skips registration entirely
5. **Failure outcome** — failed tool call records failure status with correct classification

### Approach

No live OpenClaw instance needed. The mock captures everything `register()` installs, then invokes handlers the same way OpenClaw's event system would. Uses temp directories for keys/DB, cleaned up after each test.

Closes #6

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm test` — 60/60 pass (55 existing + 5 new)