### PR TITLE
ci: add npm publish workflow with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -29,12 +31,21 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Verify release tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Release tag v${TAG_VERSION} does not match package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+
       - run: pnpm run typecheck
 
       - run: pnpm test
 
       - run: pnpm run build
 
-      - run: pnpm publish --access public --no-git-checks --provenance
+      - run: pnpm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Publishes to npm when a GitHub Release is created
- Uses OIDC provenance attestation (`--provenance` flag)
- Runs typecheck + tests + build before publishing
- Requires `NPM_TOKEN` secret to be configured in repo settings

## Setup needed
1. Generate an npm access token (automation type) at https://www.npmjs.com/settings/tokens
2. Add it as `NPM_TOKEN` in repo Settings → Secrets → Actions

Closes #3