### PR TITLE
fix: use npm trusted publishing (OIDC) instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,5 +47,3 @@ jobs:
       - run: pnpm run build
 
       - run: pnpm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Removes `NPM_TOKEN` secret reference from publish workflow
- Relies on npm's OIDC trusted publishing — GitHub Actions identity authenticates directly with npm
- No stored secrets needed

## Setup needed
Configure the trusted publisher on npmjs.com:
1. Go to https://www.npmjs.com/package/@attest-protocol/openclaw-attest/access
2. Add a trusted publisher: `attest-protocol/openclaw-attest`, workflow `publish.yml`