### PR TITLE
fix: add registry-url to setup-node for npm OIDC auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install --frozen-lockfile
 
@@ -46,4 +47,5 @@ jobs:
 
       - run: pnpm run build
 
-      - run: npm publish --access public --provenance
+      - name: Publish to npm
+        run: npm publish --access public --provenance

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Otto Jongerius",
   "repository": {
     "type": "git",
-    "url": "https://github.com/attest-protocol/openclaw-attest.git"
+    "url": "git+https://github.com/attest-protocol/openclaw-attest.git"
   },
   "keywords": [
     "openclaw",
@@ -24,7 +24,7 @@
     }
   },
   "bin": {
-    "openclaw-attest": "./dist/src/cli.js"
+    "openclaw-attest": "dist/src/cli.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- Add `registry-url: "https://registry.npmjs.org"` to the second `setup-node` step (the one with pnpm cache)
- This writes the `.npmrc` config npm needs to detect the OIDC token endpoint for trusted publishing
- Rename publish step for clarity
- Normalize `package.json` repository URL and bin path (cosmetic, auto-corrected by npm)

## Test plan

- [x] Merge PR
- [ ] Retag v0.2.0 to new commit
- [x] Trigger `workflow_dispatch` on v0.2.0 tag — should publish to npm with OIDC provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)