### PR TITLE
fix: remove registry-url from setup-node for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install --frozen-lockfile
 
@@ -48,4 +47,6 @@ jobs:
       - run: pnpm run build
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: |
+          npm config set registry https://registry.npmjs.org/
+          npm publish --access public --provenance


### PR DESCRIPTION
## Summary

`actions/setup-node` with `registry-url` writes `_authToken=${NODE_AUTH_TOKEN}` to `.npmrc`. With no `NODE_AUTH_TOKEN` set, npm sends an empty bearer token and the registry returns 404.

Fix: remove `registry-url` from `setup-node` and configure the registry manually (`npm config set registry ...`) without any auth token. npm then falls back to OIDC trusted publishing automatically.

## Test plan

- [ ] Merge and retag v0.2.0
- [ ] Trigger workflow — should publish 0.2.0 with OIDC provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)