### PR TITLE
fix: strip _authToken from .npmrc for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install --frozen-lockfile
 
@@ -48,5 +49,5 @@ jobs:
 
       - name: Publish to npm
         run: |
-          npm config set registry https://registry.npmjs.org/
+          sed -i '/_authToken/d' ~/.npmrc
           npm publish --access public --provenance


### PR DESCRIPTION
setup-node writes `_authToken=${NODE_AUTH_TOKEN}` to .npmrc. Empty token → 404. Strip the line so npm falls back to OIDC while keeping registry config.