### PR TITLE
fix: remove sed command from publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,4 @@ jobs:
       - run: pnpm run build
 
       - name: Publish to npm
-        run: |
-          sed -i '/_authToken/d' ~/.npmrc
-          npm publish --access public --provenance
+        run: npm publish --access public --provenance


### PR DESCRIPTION
sed was targeting wrong path. NODE_AUTH_TOKEN is set — just let setup-node handle auth.