### PR TITLE
fix: use npm config delete and update npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           node-version: "22"
 
+      - run: npm install -g npm@latest
+
       - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
 
       - uses: actions/setup-node@v4
@@ -48,4 +50,6 @@ jobs:
       - run: pnpm run build
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: |
+          npm config delete //registry.npmjs.org/:_authToken
+          npm publish --access public --provenance


### PR DESCRIPTION
- Update npm to latest (trusted publishing requires >=11.5.1)
- Use `npm config delete //registry.npmjs.org/:_authToken` to remove the token setup-node writes, respecting NPM_CONFIG_USERCONFIG so the right file is targeted
- Allows OIDC to take over for auth