### PR TITLE
chore: rename to @agnt-rcpt/openclaw

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,6 @@ CI runs typecheck + vitest + V8 coverage via GitHub Actions.
 
 ## Dependencies
 
-- `@attest-protocol/attest-ts` — Attest Protocol SDK (receipts, store, signing)
+- `@agnt-rcpt/sdk-ts` — Attest Protocol SDK (receipts, store, signing)
 - `@sinclair/typebox` — JSON schema for tool parameter validation
 - `openclaw` — peer dependency (`>=2025.0.0`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions are welcome! This plugin is part of the [Attest Protocol](https://github.com/attest-protocol) ecosystem.
+Contributions are welcome! This plugin is part of the [Attest Protocol](https://github.com/agnt-rcpt) ecosystem.
 
 ## Reporting Issues
 
@@ -14,8 +14,8 @@ Open a GitHub issue for:
 ## Development Setup
 
 ```bash
-git clone https://github.com/attest-protocol/openclaw-attest.git
-cd openclaw-attest
+git clone https://github.com/agnt-rcpt/openclaw.git
+cd openclaw
 pnpm install
 ```
 
@@ -49,7 +49,7 @@ Adding mappings for new OpenClaw tools is a great way to contribute. Edit `taxon
 
 ## Spec Alignment
 
-This plugin implements the [Action Receipt Protocol](https://github.com/attest-protocol/spec) via the `@attest-protocol/attest-ts` SDK. Changes must remain compatible with the protocol specification.
+This plugin implements the [Action Receipt Protocol](https://github.com/agnt-rcpt/spec) via the `@agnt-rcpt/sdk-ts` SDK. Changes must remain compatible with the protocol specification.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 <div align="center">
 
-# openclaw-attest
+# openclaw
 
 ### Attest Protocol plugin for OpenClaw
 
-[![npm](https://img.shields.io/npm/v/@attest-protocol/openclaw-attest)](https://www.npmjs.com/package/@attest-protocol/openclaw-attest)
+[![npm](https://img.shields.io/npm/v/@agnt-rcpt/openclaw)](https://www.npmjs.com/package/@agnt-rcpt/openclaw)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ESM-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![CI](https://github.com/attest-protocol/openclaw-attest/actions/workflows/ci.yml/badge.svg)](https://github.com/attest-protocol/openclaw-attest/actions/workflows/ci.yml)
+[![CI](https://github.com/agnt-rcpt/openclaw/actions/workflows/ci.yml/badge.svg)](https://github.com/agnt-rcpt/openclaw/actions/workflows/ci.yml)
 
 ---
 
 Cryptographically signed, hash-linked audit trail for every tool call an OpenClaw agent makes.
 
-Built on [`@attest-protocol/attest-ts`](https://github.com/attest-protocol/attest-ts) and [`@sinclair/typebox`](https://github.com/sinclairzx81/typebox).
+Built on [`@agnt-rcpt/sdk-ts`](https://github.com/agnt-rcpt/sdk-ts) and [`@sinclair/typebox`](https://github.com/sinclairzx81/typebox).
 
-[Spec](https://github.com/attest-protocol/spec) &bull; [TypeScript SDK](https://github.com/attest-protocol/attest-ts) &bull; [Python SDK](https://github.com/attest-protocol/attest-py)
+[Spec](https://github.com/agnt-rcpt/spec) &bull; [TypeScript SDK](https://github.com/agnt-rcpt/sdk-ts) &bull; [Python SDK](https://github.com/agnt-rcpt/sdk-py)
 
 </div>
 
@@ -71,13 +71,13 @@ AI agents that read files, run commands, and browse the web are powerful — but
 
 ### Beyond local storage
 
-Today, receipts are stored locally in SQLite — fully under your control. The [Attest Protocol](https://github.com/attest-protocol/spec) is designed for receipts to travel further when you choose: publishing to a shared ledger, forwarding to a compliance system, or exchanging with other agents as proof of prior actions. The receipts are portable W3C Verifiable Credentials, but where they go is always your decision.
+Today, receipts are stored locally in SQLite — fully under your control. The [Attest Protocol](https://github.com/agnt-rcpt/spec) is designed for receipts to travel further when you choose: publishing to a shared ledger, forwarding to a compliance system, or exchanging with other agents as proof of prior actions. The receipts are portable W3C Verifiable Credentials, but where they go is always your decision.
 
 ## How it works
 
 Every time the OpenClaw agent executes a tool, this plugin:
 
-1. **Classifies the action** using the [Attest Protocol taxonomy](https://github.com/attest-protocol/spec/tree/main/spec/taxonomy)
+1. **Classifies the action** using the [Attest Protocol taxonomy](https://github.com/agnt-rcpt/spec/tree/main/spec/taxonomy)
 2. **Creates a signed receipt** — a [W3C Verifiable Credential](https://www.w3.org/TR/vc-data-model-2.0/) with Ed25519 proof
 3. **Hash-links it** into a per-session chain (tamper-evident)
 4. **Stores it** in a local SQLite database
@@ -97,7 +97,7 @@ OpenClaw Gateway
 ## Install
 
 ```bash
-openclaw plugins install @attest-protocol/openclaw-attest
+openclaw plugins install @agnt-rcpt/openclaw
 ```
 
 Then enable the plugin in your OpenClaw config. See [`docs/INSTALL.md`](docs/INSTALL.md) for tool visibility setup and configuration options.
@@ -108,31 +108,31 @@ Query and verify receipts outside of agent sessions, useful for auditing and deb
 
 ```bash
 # Query all receipts
-npx @attest-protocol/openclaw-attest receipts
+npx @agnt-rcpt/openclaw receipts
 
 # Filter by risk level
-npx @attest-protocol/openclaw-attest receipts --risk high
+npx @agnt-rcpt/openclaw receipts --risk high
 
 # Filter by action type and output as JSON
-npx @attest-protocol/openclaw-attest receipts --action system.command.execute --json
+npx @agnt-rcpt/openclaw receipts --action system.command.execute --json
 
 # Verify all chains
-npx @attest-protocol/openclaw-attest verify
+npx @agnt-rcpt/openclaw verify
 
 # Verify a specific chain
-npx @attest-protocol/openclaw-attest verify --chain chain_openclaw_main_sid-42
+npx @agnt-rcpt/openclaw verify --chain chain_openclaw_main_sid-42
 
 # Export a chain as JSON-LD (full W3C Verifiable Credentials)
-npx @attest-protocol/openclaw-attest export --chain chain_openclaw_main_sid-42
+npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42
 
 # Export as a W3C Verifiable Presentation envelope
-npx @attest-protocol/openclaw-attest export --chain chain_openclaw_main_sid-42 --format presentation
+npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42 --format presentation
 
 # Export a single receipt by ID
-npx @attest-protocol/openclaw-attest export --id urn:receipt:abc-123
+npx @agnt-rcpt/openclaw export --id urn:receipt:abc-123
 ```
 
-Run `npx @attest-protocol/openclaw-attest --help` for all options including `--status`, `--limit`, and `--db`.
+Run `npx @agnt-rcpt/openclaw --help` for all options including `--status`, `--limit`, and `--db`.
 
 ## Agent tools
 
@@ -211,7 +211,7 @@ Ed25519 signing keys are generated automatically on first run and persisted to `
 ```
 src/
   index.ts          # Plugin entry — wires hooks, tools, service
-  cli.ts            # Receipt Explorer CLI (npx @attest-protocol/openclaw-attest)
+  cli.ts            # Receipt Explorer CLI (npx @agnt-rcpt/openclaw)
   hooks.ts          # before_tool_call / after_tool_call → receipt creation
   classify.ts       # Tool name → action type + risk level classification
   chain.ts          # Per-session hash-linked chain state
@@ -233,16 +233,16 @@ pnpm test:coverage     # with V8 coverage
 |:---|:---|
 | **Language** | TypeScript ESM, strict mode |
 | **Testing** | Vitest (colocated `*.test.ts` files) |
-| **Runtime deps** | `@attest-protocol/attest-ts` + `@sinclair/typebox` |
+| **Runtime deps** | `@agnt-rcpt/sdk-ts` + `@sinclair/typebox` |
 
 ## Ecosystem
 
 | Repository | Description |
 |:---|:---|
-| [attest-protocol/spec](https://github.com/attest-protocol/spec) | Protocol specification, JSON Schemas, canonical taxonomy |
-| [attest-protocol/attest-ts](https://github.com/attest-protocol/attest-ts) | TypeScript SDK |
-| [attest-protocol/attest-py](https://github.com/attest-protocol/attest-py) | Python SDK ([PyPI](https://pypi.org/project/attest-protocol/)) |
-| **attest-protocol/openclaw-attest** (this plugin) | OpenClaw integration |
+| [agnt-rcpt/spec](https://github.com/agnt-rcpt/spec) | Protocol specification, JSON Schemas, canonical taxonomy |
+| [agnt-rcpt/sdk-ts](https://github.com/agnt-rcpt/sdk-ts) | TypeScript SDK |
+| [agnt-rcpt/sdk-py](https://github.com/agnt-rcpt/sdk-py) | Python SDK ([PyPI](https://pypi.org/project/agnt-rcpt/)) |
+| **agnt-rcpt/openclaw** (this plugin) | OpenClaw integration |
 | [ojongerius/attest](https://github.com/ojongerius/attest) | MCP proxy + CLI (reference implementation) |
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ Security reports for this plugin cover:
 - Injection attacks through tool parameters or taxonomy config
 - Privilege escalation through the plugin's OpenClaw hooks
 
-Issues in the underlying `@attest-protocol/attest-ts` SDK should be reported to the [attest-ts repository](https://github.com/attest-protocol/attest-ts/security).
+Issues in the underlying `@agnt-rcpt/sdk-ts` SDK should be reported to the [attest-ts repository](https://github.com/agnt-rcpt/sdk-ts/security).
 
 ## Disclosure Policy
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,13 +1,13 @@
-# Installing openclaw-attest
+# Installing openclaw
 
 ## Quick start
 
 ```bash
 # Install the plugin
-openclaw plugins install @attest-protocol/openclaw-attest
+openclaw plugins install @agnt-rcpt/openclaw
 
 # Or link a local clone for development
-openclaw plugins install /path/to/openclaw-attest --link
+openclaw plugins install /path/to/openclaw --link
 ```
 
 ## Tool visibility
@@ -34,7 +34,7 @@ tools, or allowlist the entire plugin by ID:
 ```jsonc
 {
   "tools": {
-    "alsoAllow": ["openclaw-attest"]
+    "alsoAllow": ["openclaw"]
   }
 }
 ```
@@ -47,7 +47,7 @@ All config is optional with sensible defaults:
 {
   "plugins": {
     "entries": {
-      "openclaw-attest": {
+      "openclaw": {
         "enabled": true,
         "config": {
           "enabled": true,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "openclaw-attest",
+  "id": "openclaw",
   "name": "Attest Protocol",
   "description": "Cryptographically signed audit trail for agent actions",
   "contracts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@attest-protocol/openclaw-attest",
+  "name": "@agnt-rcpt/openclaw",
   "version": "0.2.0",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Attest Protocol",
   "type": "module",
@@ -7,11 +7,11 @@
   "author": "Otto Jongerius",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/attest-protocol/openclaw-attest.git"
+    "url": "git+https://github.com/agnt-rcpt/openclaw.git"
   },
   "keywords": [
     "openclaw",
-    "attest-protocol",
+    "agnt-rcpt",
     "audit-trail",
     "receipts",
     "verifiable-credentials",
@@ -24,7 +24,7 @@
     }
   },
   "bin": {
-    "openclaw-attest": "dist/src/cli.js"
+    "openclaw": "dist/src/cli.js"
   },
   "files": [
     "dist",
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@attest-protocol/attest-ts": "^0.1.0",
+    "@agnt-rcpt/sdk-ts": "^0.1.0",
     "@sinclair/typebox": "0.34.49"
   },
   "devDependencies": {

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Demo: generate a nice screenshot-worthy output from openclaw-attest
+# Demo: generate a nice screenshot-worthy output from openclaw
 #
 # Prerequisites:
 #   - Plugin installed and alsoAllow configured (run smoke-test.sh first)

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# Smoke test: openclaw-attest plugin with a live OpenClaw instance
+# Smoke test: openclaw plugin with a live OpenClaw instance
 #
 # Run this inside a `script` session to record everything:
-#   script -q ~/repos/openclaw-attest/scripts/smoke-test-recording.txt bash scripts/smoke-test.sh
+#   script -q ~/repos/openclaw/scripts/smoke-test-recording.txt bash scripts/smoke-test.sh
 #
 # Prerequisites:
 #   - ANTHROPIC_API_KEY set in environment
@@ -24,7 +24,7 @@ $OPENCLAW --dev onboard --non-interactive --accept-risk --skip-health \
   --anthropic-api-key "$ANTHROPIC_API_KEY"
 
 echo ""
-echo "=== 2. Installing openclaw-attest plugin (linked) ==="
+echo "=== 2. Installing openclaw plugin (linked) ==="
 $OPENCLAW --dev plugins install . --link
 
 echo ""

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -4,12 +4,12 @@ import {
   resolveActionType,
   type ClassificationResult,
   type TaxonomyMapping,
-} from "@attest-protocol/attest-ts/taxonomy";
+} from "@agnt-rcpt/sdk-ts/taxonomy";
 
 // Default mappings bundled with the plugin
 import defaultTaxonomy from "../taxonomy.json" with { type: "json" };
 
-export { type TaxonomyMapping } from "@attest-protocol/attest-ts/taxonomy";
+export { type TaxonomyMapping } from "@agnt-rcpt/sdk-ts/taxonomy";
 
 export interface TaxonomyPattern {
   prefix: string;

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -149,7 +149,7 @@ describe("parseCliArgs", () => {
 describe("helpText", () => {
   it("includes usage information", () => {
     const text = helpText();
-    expect(text).toContain("openclaw-attest");
+    expect(text).toContain("openclaw");
     expect(text).toContain("receipts");
     expect(text).toContain("verify");
     expect(text).toContain("export");
@@ -352,7 +352,7 @@ describe("run", () => {
 
   it("outputs help text with --help", () => {
     run(["--help"]);
-    expect(stdoutData).toContain("openclaw-attest");
+    expect(stdoutData).toContain("openclaw");
     expect(stdoutData).toContain("receipts");
     expect(stdoutData).toContain("verify");
     expect(stdoutData).toContain("export");
@@ -360,7 +360,7 @@ describe("run", () => {
 
   it("outputs version with --version", () => {
     run(["--version"]);
-    expect(stdoutData).toContain("openclaw-attest v");
+    expect(stdoutData).toContain("openclaw v");
   });
 
   it("throws on unknown command", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,25 +1,25 @@
 #!/usr/bin/env node
 
 /**
- * Receipt Explorer CLI for openclaw-attest.
+ * Receipt Explorer CLI for openclaw.
  *
  * Query and verify the SQLite receipt database outside of the agent.
  * Useful for auditing and debugging.
  *
  * Usage:
- *   openclaw-attest receipts [--risk <level>] [--action <type>] [--status <status>] [--limit <n>] [--db <path>] [--json]
- *   openclaw-attest verify [--chain <id>] [--db <path>] [--json]
- *   openclaw-attest export [--chain <id>] [--id <receipt-id>] [--format receipt|presentation] [--db <path>]
- *   openclaw-attest --help
- *   openclaw-attest --version
+ *   openclaw receipts [--risk <level>] [--action <type>] [--status <status>] [--limit <n>] [--db <path>] [--json]
+ *   openclaw verify [--chain <id>] [--db <path>] [--json]
+ *   openclaw export [--chain <id>] [--id <receipt-id>] [--format receipt|presentation] [--db <path>]
+ *   openclaw --help
+ *   openclaw --version
  */
 
 import { parseArgs } from "node:util";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
-import { openStore, verifyStoredChain } from "@attest-protocol/attest-ts";
-import type { ActionReceipt, RiskLevel, OutcomeStatus, ReceiptStore, StoreStats } from "@attest-protocol/attest-ts";
+import { openStore, verifyStoredChain } from "@agnt-rcpt/sdk-ts";
+import type { ActionReceipt, RiskLevel, OutcomeStatus, ReceiptStore, StoreStats } from "@agnt-rcpt/sdk-ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -101,14 +101,14 @@ function loadVersion(): string {
 // ---------------------------------------------------------------------------
 
 export function helpText(): string {
-  return `openclaw-attest — Receipt Explorer CLI
+  return `openclaw — Receipt Explorer CLI
 
 Usage:
-  openclaw-attest receipts [options]   Query receipts from the audit trail
-  openclaw-attest verify  [options]    Verify chain integrity
-  openclaw-attest export  [options]    Export receipts as JSON-LD
-  openclaw-attest --help               Show this help
-  openclaw-attest --version            Show version
+  openclaw receipts [options]   Query receipts from the audit trail
+  openclaw verify  [options]    Verify chain integrity
+  openclaw export  [options]    Export receipts as JSON-LD
+  openclaw --help               Show this help
+  openclaw --version            Show version
 
 receipts options:
   --risk <level>     Filter by risk level (low, medium, high, critical)
@@ -532,7 +532,7 @@ export function run(argv: string[]): void {
       break;
 
     case "version":
-      process.stdout.write(`openclaw-attest v${loadVersion()}\n`);
+      process.stdout.write(`openclaw v${loadVersion()}\n`);
       break;
 
     case "receipts":

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { generateKeyPair, type KeyPair } from "@attest-protocol/attest-ts";
+import { generateKeyPair, type KeyPair } from "@agnt-rcpt/sdk-ts";
 
 export type AttestPluginConfig = {
   dbPath?: string;

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -5,7 +5,7 @@ import {
   canonicalize,
   sha256,
   type ReceiptStore,
-} from "@attest-protocol/attest-ts";
+} from "@agnt-rcpt/sdk-ts";
 import { beforeToolCall, afterToolCall } from "./hooks.js";
 import { makeHookDeps, simulateToolCall } from "./test-helpers.js";
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -15,8 +15,8 @@ import {
   canonicalize,
   sha256,
   type ReceiptStore,
-} from "@attest-protocol/attest-ts";
-import type { TaxonomyMapping } from "@attest-protocol/attest-ts/taxonomy";
+} from "@agnt-rcpt/sdk-ts";
+import type { TaxonomyMapping } from "@agnt-rcpt/sdk-ts/taxonomy";
 
 import { classify, type TaxonomyPattern } from "./classify.js";
 import { type ChainsMap, getChainState, advanceChain } from "./chain.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * openclaw-attest — Attest Protocol plugin for OpenClaw
+ * openclaw — Attest Protocol plugin for OpenClaw
  *
  * Generates cryptographically signed, hash-linked action receipts
  * for every tool call the agent makes, creating a tamper-evident
@@ -9,7 +9,7 @@
 import { dirname } from "node:path";
 import { mkdirSync } from "node:fs";
 import { definePluginEntry } from "./openclaw-types.js";
-import { openStore } from "@attest-protocol/attest-ts";
+import { openStore } from "@agnt-rcpt/sdk-ts";
 
 import { resolveConfig, loadOrCreateKeys } from "./config.js";
 import { loadCustomMappings, DEFAULT_MAPPINGS, DEFAULT_PATTERNS } from "./classify.js";
@@ -18,7 +18,7 @@ import { resetChain, getChainId, type ChainsMap, type ChainState } from "./chain
 import { createQueryReceiptsToolFactory, createVerifyChainToolFactory } from "./tools.js";
 
 export default definePluginEntry({
-  id: "openclaw-attest",
+  id: "openclaw",
   name: "Attest Protocol",
   description: "Cryptographically signed audit trail for agent actions",
 

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,12 +1,12 @@
 /**
- * Shared test utilities for openclaw-attest tests.
+ * Shared test utilities for openclaw tests.
  */
 
 import {
   generateKeyPair,
   openStore,
   type ReceiptStore,
-} from "@attest-protocol/attest-ts";
+} from "@agnt-rcpt/sdk-ts";
 import { beforeToolCall, afterToolCall, type HookDeps, type PendingMap } from "./hooks.js";
 import { type ChainsMap, type ChainState } from "./chain.js";
 import { DEFAULT_MAPPINGS, DEFAULT_PATTERNS } from "./classify.js";

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { openStore, type ReceiptStore } from "@attest-protocol/attest-ts";
+import { openStore, type ReceiptStore } from "@agnt-rcpt/sdk-ts";
 import { createQueryReceiptsTool, createVerifyChainTool, createVerifyChainToolFactory } from "./tools.js";
 import { makeHookDeps, simulateToolCall } from "./test-helpers.js";
 import { getChainId } from "./chain.js";

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,8 +6,8 @@
  */
 
 import { Type } from "@sinclair/typebox";
-import type { ReceiptStore, RiskLevel, OutcomeStatus } from "@attest-protocol/attest-ts";
-import { verifyStoredChain } from "@attest-protocol/attest-ts";
+import type { ReceiptStore, RiskLevel, OutcomeStatus } from "@agnt-rcpt/sdk-ts";
+import { verifyStoredChain } from "@agnt-rcpt/sdk-ts";
 
 const VALID_RISK_LEVELS = new Set<string>(["low", "medium", "high", "critical"]);
 const VALID_STATUSES = new Set<string>(["success", "failure", "pending"]);


### PR DESCRIPTION
## Summary
- Rename npm package from `@attest-protocol/openclaw-attest` to `@agnt-rcpt/openclaw`
- Update dependency from `@attest-protocol/attest-ts` to `@agnt-rcpt/sdk-ts`
- Update all source imports and plugin ID (19 files)
- Update all documentation, scripts, and cross-repo links

## Test plan
- [ ] Verify no remaining references to old names
- [ ] Run test suite (note: may fail until @agnt-rcpt/sdk-ts is published to npm)