### PR TITLE
Use @agnt-rcpt npm scope and fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,17 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - run: npm install -g npm@latest
-
       - run: corepack enable && corepack prepare pnpm@10.33.0 --activate
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,6 @@ CI runs typecheck + vitest + V8 coverage via GitHub Actions.
 
 ## Dependencies
 
-- `@agent-receipts/sdk-ts` — Agent Receipts SDK (receipts, store, signing)
+- `@agnt-rcpt/sdk-ts` — Agent Receipts SDK (receipts, store, signing)
 - `@sinclair/typebox` — JSON schema for tool parameter validation
 - `openclaw` — peer dependency (`>=2025.0.0`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Adding mappings for new OpenClaw tools is a great way to contribute. Edit `taxon
 
 ## Spec Alignment
 
-This plugin implements the [Action Receipt Protocol](https://github.com/agent-receipts/spec) via the `@agent-receipts/sdk-ts` SDK. Changes must remain compatible with the protocol specification.
+This plugin implements the [Action Receipt Protocol](https://github.com/agent-receipts/spec) via the `@agnt-rcpt/sdk-ts` SDK. Changes must remain compatible with the protocol specification.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Attest Protocol plugin for OpenClaw
 
-[![npm](https://img.shields.io/npm/v/@agent-receipts/openclaw)](https://www.npmjs.com/package/@agent-receipts/openclaw)
+[![npm](https://img.shields.io/npm/v/@agnt-rcpt/openclaw)](https://www.npmjs.com/package/@agnt-rcpt/openclaw)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ESM-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![CI](https://github.com/agent-receipts/openclaw/actions/workflows/ci.yml/badge.svg)](https://github.com/agent-receipts/openclaw/actions/workflows/ci.yml)
@@ -13,9 +13,9 @@
 
 Cryptographically signed, hash-linked audit trail for every tool call an OpenClaw agent makes.
 
-Built on [`@agent-receipts/sdk-ts`](https://github.com/agent-receipts/sdk-ts) and [`@sinclair/typebox`](https://github.com/sinclairzx81/typebox).
+Built on [`@agnt-rcpt/sdk-ts`](https://github.com/agent-receipts/ar/tree/main/sdk/ts) and [`@sinclair/typebox`](https://github.com/sinclairzx81/typebox).
 
-[Spec](https://github.com/agent-receipts/spec) &bull; [TypeScript SDK](https://github.com/agent-receipts/sdk-ts) &bull; [Python SDK](https://github.com/agent-receipts/sdk-py)
+[Spec](https://github.com/agent-receipts/ar/tree/main/spec) &bull; [TypeScript SDK](https://github.com/agent-receipts/ar/tree/main/sdk/ts) &bull; [Python SDK](https://github.com/agent-receipts/ar/tree/main/sdk/py)
 
 </div>
 
@@ -71,13 +71,13 @@ AI agents that read files, run commands, and browse the web are powerful — but
 
 ### Beyond local storage
 
-Today, receipts are stored locally in SQLite — fully under your control. The [Attest Protocol](https://github.com/agent-receipts/spec) is designed for receipts to travel further when you choose: publishing to a shared ledger, forwarding to a compliance system, or exchanging with other agents as proof of prior actions. The receipts are portable W3C Verifiable Credentials, but where they go is always your decision.
+Today, receipts are stored locally in SQLite — fully under your control. The [Attest Protocol](https://github.com/agent-receipts/ar/tree/main/spec) is designed for receipts to travel further when you choose: publishing to a shared ledger, forwarding to a compliance system, or exchanging with other agents as proof of prior actions. The receipts are portable W3C Verifiable Credentials, but where they go is always your decision.
 
 ## How it works
 
 Every time the OpenClaw agent executes a tool, this plugin:
 
-1. **Classifies the action** using the [Attest Protocol taxonomy](https://github.com/agent-receipts/spec/tree/main/spec/taxonomy)
+1. **Classifies the action** using the [Attest Protocol taxonomy](https://github.com/agent-receipts/ar/tree/main/spec/tree/main/spec/taxonomy)
 2. **Creates a signed receipt** — a [W3C Verifiable Credential](https://www.w3.org/TR/vc-data-model-2.0/) with Ed25519 proof
 3. **Hash-links it** into a per-session chain (tamper-evident)
 4. **Stores it** in a local SQLite database
@@ -97,7 +97,7 @@ OpenClaw Gateway
 ## Install
 
 ```bash
-openclaw plugins install @agent-receipts/openclaw
+openclaw plugins install @agnt-rcpt/openclaw
 ```
 
 Then enable the plugin in your OpenClaw config. See [`docs/INSTALL.md`](docs/INSTALL.md) for tool visibility setup and configuration options.
@@ -108,31 +108,31 @@ Query and verify receipts outside of agent sessions, useful for auditing and deb
 
 ```bash
 # Query all receipts
-npx @agent-receipts/openclaw receipts
+npx @agnt-rcpt/openclaw receipts
 
 # Filter by risk level
-npx @agent-receipts/openclaw receipts --risk high
+npx @agnt-rcpt/openclaw receipts --risk high
 
 # Filter by action type and output as JSON
-npx @agent-receipts/openclaw receipts --action system.command.execute --json
+npx @agnt-rcpt/openclaw receipts --action system.command.execute --json
 
 # Verify all chains
-npx @agent-receipts/openclaw verify
+npx @agnt-rcpt/openclaw verify
 
 # Verify a specific chain
-npx @agent-receipts/openclaw verify --chain chain_openclaw_main_sid-42
+npx @agnt-rcpt/openclaw verify --chain chain_openclaw_main_sid-42
 
 # Export a chain as JSON-LD (full W3C Verifiable Credentials)
-npx @agent-receipts/openclaw export --chain chain_openclaw_main_sid-42
+npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42
 
 # Export as a W3C Verifiable Presentation envelope
-npx @agent-receipts/openclaw export --chain chain_openclaw_main_sid-42 --format presentation
+npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42 --format presentation
 
 # Export a single receipt by ID
-npx @agent-receipts/openclaw export --id urn:receipt:abc-123
+npx @agnt-rcpt/openclaw export --id urn:receipt:abc-123
 ```
 
-Run `npx @agent-receipts/openclaw --help` for all options including `--status`, `--limit`, and `--db`.
+Run `npx @agnt-rcpt/openclaw --help` for all options including `--status`, `--limit`, and `--db`.
 
 ## Agent tools
 
@@ -211,7 +211,7 @@ Ed25519 signing keys are generated automatically on first run and persisted to `
 ```
 src/
   index.ts          # Plugin entry — wires hooks, tools, service
-  cli.ts            # Receipt Explorer CLI (npx @agent-receipts/openclaw)
+  cli.ts            # Receipt Explorer CLI (npx @agnt-rcpt/openclaw)
   hooks.ts          # before_tool_call / after_tool_call → receipt creation
   classify.ts       # Tool name → action type + risk level classification
   chain.ts          # Per-session hash-linked chain state
@@ -233,15 +233,15 @@ pnpm test:coverage     # with V8 coverage
 |:---|:---|
 | **Language** | TypeScript ESM, strict mode |
 | **Testing** | Vitest (colocated `*.test.ts` files) |
-| **Runtime deps** | `@agent-receipts/sdk-ts` + `@sinclair/typebox` |
+| **Runtime deps** | `@agnt-rcpt/sdk-ts` + `@sinclair/typebox` |
 
 ## Ecosystem
 
 | Repository | Description |
 |:---|:---|
-| [agent-receipts/spec](https://github.com/agent-receipts/spec) | Protocol specification, JSON Schemas, canonical taxonomy |
-| [agent-receipts/sdk-ts](https://github.com/agent-receipts/sdk-ts) | TypeScript SDK |
-| [agent-receipts/sdk-py](https://github.com/agent-receipts/sdk-py) | Python SDK ([PyPI](https://pypi.org/project/agent-receipts/)) |
+| [agent-receipts/spec](https://github.com/agent-receipts/ar/tree/main/spec) | Protocol specification, JSON Schemas, canonical taxonomy |
+| [agent-receipts/sdk-ts](https://github.com/agent-receipts/ar/tree/main/sdk/ts) | TypeScript SDK |
+| [agent-receipts/sdk-py](https://github.com/agent-receipts/ar/tree/main/sdk/py) | Python SDK ([PyPI](https://pypi.org/project/agent-receipts/)) |
 | **agent-receipts/openclaw** (this plugin) | OpenClaw integration |
 | [ojongerius/attest](https://github.com/ojongerius/attest) | MCP proxy + CLI (reference implementation) |
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,7 +4,7 @@
 
 ```bash
 # Install the plugin
-openclaw plugins install @agent-receipts/openclaw
+openclaw plugins install @agnt-rcpt/openclaw
 
 # Or link a local clone for development
 openclaw plugins install /path/to/openclaw-attest --link

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-receipts/openclaw",
+  "name": "@agnt-rcpt/openclaw",
   "version": "0.2.0",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Attest Protocol",
   "type": "module",


### PR DESCRIPTION
- Rename to @agnt-rcpt/openclaw and @agnt-rcpt/sdk-ts (matching npm org)
- Fix publish workflow: remove broken npm self-upgrade, Node 24
- Update links to point to monorepo