### PR TITLE
Fix publish workflow auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,4 @@ jobs:
       - run: pnpm run build
 
       - name: Publish to npm
-        run: |
-          npm config delete //registry.npmjs.org/:_authToken
-          npm publish --access public --provenance
+        run: npm publish --access public --provenance


### PR DESCRIPTION
The `npm config delete` line was wiping the OIDC token set by setup-node.