### PR TITLE
Rename Attest Protocol to Agent Receipts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 OpenClaw plugin that generates cryptographically signed, hash-linked audit trails
-for every tool call an agent makes, using the Attest Protocol. Receipts are W3C
+for every tool call an agent makes, using Agent Receipts. Receipts are W3C
 Verifiable Credentials stored in a local SQLite database.
 
 ## Commands

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Attest Protocol Contributors
+Copyright (c) 2026 Agent Receipts Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # openclaw-attest
 
-### Attest Protocol plugin for OpenClaw
+### Agent Receipts plugin for OpenClaw
 
 [![npm](https://img.shields.io/npm/v/@agnt-rcpt/openclaw)](https://www.npmjs.com/package/@agnt-rcpt/openclaw)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -71,13 +71,13 @@ AI agents that read files, run commands, and browse the web are powerful — but
 
 ### Beyond local storage
 
-Today, receipts are stored locally in SQLite — fully under your control. The [Attest Protocol](https://github.com/agent-receipts/ar/tree/main/spec) is designed for receipts to travel further when you choose: publishing to a shared ledger, forwarding to a compliance system, or exchanging with other agents as proof of prior actions. The receipts are portable W3C Verifiable Credentials, but where they go is always your decision.
+Today, receipts are stored locally in SQLite — fully under your control. The [Agent Receipts protocol](https://github.com/agent-receipts/ar/tree/main/spec) is designed for receipts to travel further when you choose: publishing to a shared ledger, forwarding to a compliance system, or exchanging with other agents as proof of prior actions. The receipts are portable W3C Verifiable Credentials, but where they go is always your decision.
 
 ## How it works
 
 Every time the OpenClaw agent executes a tool, this plugin:
 
-1. **Classifies the action** using the [Attest Protocol taxonomy](https://github.com/agent-receipts/ar/tree/main/spec/tree/main/spec/taxonomy)
+1. **Classifies the action** using the [Agent Receipts taxonomy](https://github.com/agent-receipts/ar/tree/main/spec/tree/main/spec/taxonomy)
 2. **Creates a signed receipt** — a [W3C Verifiable Credential](https://www.w3.org/TR/vc-data-model-2.0/) with Ed25519 proof
 3. **Hash-links it** into a per-session chain (tamper-evident)
 4. **Stores it** in a local SQLite database
@@ -178,7 +178,7 @@ Each receipt is a W3C Verifiable Credential signed with Ed25519, recording:
 
 ## Taxonomy
 
-The plugin maps OpenClaw tool names to Attest Protocol action types:
+The plugin maps OpenClaw tool names to Agent Receipts action types:
 
 | OpenClaw tool | Action type | Risk |
 |:---|:---|:---|

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -69,6 +69,6 @@ After setup, restart the gateway and confirm the plugin loaded:
 openclaw plugins list
 ```
 
-You should see `Attest Protocol` with status `loaded`. Then ask the agent
+You should see `Agent Receipts` with status `loaded`. Then ask the agent
 to use `attest_query_receipts` or `attest_verify_chain` to confirm the
 tools are visible.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "openclaw-attest",
-  "name": "Attest Protocol",
+  "name": "Agent Receipts",
   "description": "Cryptographically signed audit trail for agent actions",
   "contracts": {
     "tools": ["attest_query_receipts", "attest_verify_chain"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agnt-rcpt/openclaw",
   "version": "0.2.0",
-  "description": "Cryptographically signed audit trail for OpenClaw agent actions via Attest Protocol",
+  "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "MIT",
   "author": "Otto Jongerius",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * openclaw-attest — Attest Protocol plugin for OpenClaw
+ * openclaw-attest — Agent Receipts plugin for OpenClaw
  *
  * Generates cryptographically signed, hash-linked action receipts
  * for every tool call the agent makes, creating a tamper-evident
- * audit trail using the Attest Protocol TypeScript SDK.
+ * audit trail using the Agent Receipts TypeScript SDK.
  */
 
 import { dirname } from "node:path";
@@ -19,7 +19,7 @@ import { createQueryReceiptsToolFactory, createVerifyChainToolFactory } from "./
 
 export default definePluginEntry({
   id: "openclaw-attest",
-  name: "Attest Protocol",
+  name: "Agent Receipts",
   description: "Cryptographically signed audit trail for agent actions",
 
   register(api) {


### PR DESCRIPTION
## Summary
- Update all user-facing "Attest Protocol" branding to "Agent Receipts" across README, LICENSE, package.json, plugin manifest, install docs, AGENTS.md, and plugin entry point
- GitHub repo description already updated separately

## Not changed (would be breaking)
- Plugin ID `openclaw-attest` and binary name
- Tool names `attest_query_receipts` / `attest_verify_chain`
- File paths `~/.openclaw/attest/`
- Log prefixes and internal service IDs

## Test plan
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] Verify plugin loads with updated `name` field in OpenClaw