### PR TITLE
Rename all internal attest identifiers to agent-receipts/ar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ CI runs typecheck + vitest + V8 coverage via GitHub Actions.
 | `src/hooks.ts` | `before_tool_call` / `after_tool_call` handlers, receipt creation |
 | `src/chain.ts` | Per-session hash-linked chain state |
 | `src/classify.ts` | Tool name → action type + risk level via taxonomy |
-| `src/tools.ts` | Agent-facing tools: `attest_query_receipts`, `attest_verify_chain` |
+| `src/tools.ts` | Agent-facing tools: `ar_query_receipts`, `ar_verify_chain` |
 | `src/config.ts` | Config resolution, Ed25519 key management |
 | `taxonomy.json` | Source of truth for tool → action type mappings |
 | `openclaw.plugin.json` | Plugin manifest (config schema, tool contracts) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# openclaw-attest
+# openclaw-agent-receipts
 
 ### Agent Receipts plugin for OpenClaw
 
@@ -136,7 +136,7 @@ Run `npx @agnt-rcpt/openclaw --help` for all options including `--status`, `--li
 
 ## Agent tools
 
-### `attest_query_receipts`
+### `ar_query_receipts`
 
 Search the audit trail by action type, risk level, or outcome status. Returns receipt summaries and aggregate statistics.
 
@@ -152,7 +152,7 @@ Search the audit trail by action type, risk level, or outcome status. Returns re
 }
 ```
 
-### `attest_verify_chain`
+### `ar_verify_chain`
 
 Cryptographically verify the integrity of the receipt chain. Checks Ed25519 signatures, hash links, and sequence numbering.
 
@@ -200,8 +200,8 @@ All settings are optional — the plugin works out of the box with sensible defa
 | Setting | Default | Description |
 |:---|:---|:---|
 | `enabled` | `true` | Generate receipts for tool calls |
-| `dbPath` | `~/.openclaw/attest/receipts.db` | SQLite receipt database path |
-| `keyPath` | `~/.openclaw/attest/keys.json` | Ed25519 signing key pair path |
+| `dbPath` | `~/.openclaw/agent-receipts/receipts.db` | SQLite receipt database path |
+| `keyPath` | `~/.openclaw/agent-receipts/keys.json` | Ed25519 signing key pair path |
 | `taxonomyPath` | _(bundled)_ | Custom tool-to-action-type mapping |
 
 Ed25519 signing keys are generated automatically on first run and persisted to `keyPath`.
@@ -215,7 +215,7 @@ src/
   hooks.ts          # before_tool_call / after_tool_call → receipt creation
   classify.ts       # Tool name → action type + risk level classification
   chain.ts          # Per-session hash-linked chain state
-  tools.ts          # attest_query_receipts + attest_verify_chain
+  tools.ts          # ar_query_receipts + ar_verify_chain
   config.ts         # Config resolution + Ed25519 key management
 taxonomy.json       # Default OpenClaw tool → action type mappings
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,4 +1,4 @@
-# Installing openclaw-attest
+# Installing openclaw-agent-receipts
 
 ## Quick start
 
@@ -7,20 +7,20 @@
 openclaw plugins install @agnt-rcpt/openclaw
 
 # Or link a local clone for development
-openclaw plugins install /path/to/openclaw-attest --link
+openclaw plugins install /path/to/openclaw-agent-receipts --link
 ```
 
 ## Tool visibility
 
 OpenClaw's tool policy pipeline filters which tools the agent can use.
 The default `"coding"` profile does not include plugin tools, so after
-installing you must allowlist the two attest tools in your `openclaw.json`:
+installing you must allowlist the two agent-receipts tools in your `openclaw.json`:
 
 ```jsonc
 {
   "tools": {
     "profile": "coding",
-    "alsoAllow": ["attest_query_receipts", "attest_verify_chain"]
+    "alsoAllow": ["ar_query_receipts", "ar_verify_chain"]
   }
 }
 ```
@@ -34,7 +34,7 @@ tools, or allowlist the entire plugin by ID:
 ```jsonc
 {
   "tools": {
-    "alsoAllow": ["openclaw-attest"]
+    "alsoAllow": ["openclaw-agent-receipts"]
   }
 }
 ```
@@ -47,12 +47,12 @@ All config is optional with sensible defaults:
 {
   "plugins": {
     "entries": {
-      "openclaw-attest": {
+      "openclaw-agent-receipts": {
         "enabled": true,
         "config": {
           "enabled": true,
-          "dbPath": "~/.openclaw/attest/receipts.db",
-          "keyPath": "~/.openclaw/attest/keys.json",
+          "dbPath": "~/.openclaw/agent-receipts/receipts.db",
+          "keyPath": "~/.openclaw/agent-receipts/keys.json",
           "taxonomyPath": null  // custom taxonomy mapping
         }
       }
@@ -70,5 +70,5 @@ openclaw plugins list
 ```
 
 You should see `Agent Receipts` with status `loaded`. Then ask the agent
-to use `attest_query_receipts` or `attest_verify_chain` to confirm the
+to use `ar_query_receipts` or `ar_verify_chain` to confirm the
 tools are visible.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,9 +1,9 @@
 {
-  "id": "openclaw-attest",
+  "id": "openclaw-agent-receipts",
   "name": "Agent Receipts",
   "description": "Cryptographically signed audit trail for agent actions",
   "contracts": {
-    "tools": ["attest_query_receipts", "attest_verify_chain"]
+    "tools": ["ar_query_receipts", "ar_verify_chain"]
   },
   "configSchema": {
     "type": "object",
@@ -30,12 +30,12 @@
   "uiHints": {
     "dbPath": {
       "label": "Database Path",
-      "placeholder": "~/.openclaw/attest/receipts.db",
+      "placeholder": "~/.openclaw/agent-receipts/receipts.db",
       "advanced": true
     },
     "keyPath": {
       "label": "Key Path",
-      "placeholder": "~/.openclaw/attest/keys.json",
+      "placeholder": "~/.openclaw/agent-receipts/keys.json",
       "advanced": true
     },
     "taxonomyPath": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "bin": {
-    "openclaw-attest": "dist/src/cli.js"
+    "openclaw-agent-receipts": "dist/src/cli.js"
   },
   "files": [
     "dist",

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Demo: generate a nice screenshot-worthy output from openclaw-attest
+# Demo: generate a nice screenshot-worthy output from openclaw-agent-receipts
 #
 # Prerequisites:
 #   - Plugin installed and alsoAllow configured (run smoke-test.sh first)
@@ -13,7 +13,7 @@ OPENCLAW="npx --yes openclaw"
 
 echo "=== Clearing old sessions + receipts ==="
 rm -rf ~/.openclaw-dev/agents/main/sessions/*
-rm -f ~/.openclaw/attest/receipts.db
+rm -f ~/.openclaw/agent-receipts/receipts.db
 
 echo ""
 echo "=== Starting gateway ==="
@@ -24,12 +24,12 @@ sleep 5
 echo ""
 echo "=== Step 1: Generate some tool traffic ==="
 $OPENCLAW --dev agent --agent main --message \
-  "Do these three things quietly and briefly: 1) List files in /tmp 2) Read the file /etc/hostname 3) Write 'hello attest' to /tmp/attest-demo/greeting.txt"
+  "Do these three things quietly and briefly: 1) List files in /tmp 2) Read the file /etc/hostname 3) Write 'hello agent-receipts' to /tmp/ar-demo/greeting.txt"
 
 echo ""
 echo "=== Step 2: Query the audit trail ==="
 $OPENCLAW --dev agent --agent main --message \
-  "Use attest_query_receipts to show the full audit trail, then use attest_verify_chain to verify chain integrity."
+  "Use ar_query_receipts to show the full audit trail, then use ar_verify_chain to verify chain integrity."
 
 echo ""
 echo "=== Shutting down ==="

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# Smoke test: openclaw-attest plugin with a live OpenClaw instance
+# Smoke test: openclaw-agent-receipts plugin with a live OpenClaw instance
 #
 # Run this inside a `script` session to record everything:
-#   script -q ~/repos/openclaw-attest/scripts/smoke-test-recording.txt bash scripts/smoke-test.sh
+#   script -q ~/repos/openclaw-agent-receipts/scripts/smoke-test-recording.txt bash scripts/smoke-test.sh
 #
 # Prerequisites:
 #   - ANTHROPIC_API_KEY set in environment
@@ -24,11 +24,11 @@ $OPENCLAW --dev onboard --non-interactive --accept-risk --skip-health \
   --anthropic-api-key "$ANTHROPIC_API_KEY"
 
 echo ""
-echo "=== 2. Installing openclaw-attest plugin (linked) ==="
+echo "=== 2. Installing openclaw-agent-receipts plugin (linked) ==="
 $OPENCLAW --dev plugins install . --link
 
 echo ""
-echo "=== 2b. Adding attest tools to tool policy allowlist ==="
+echo "=== 2b. Adding agent-receipts tools to tool policy allowlist ==="
 # The "coding" tool profile does not include plugin tools by default.
 # Tools must be added via tools.alsoAllow for the agent to see them.
 OPENCLAW_JSON="$HOME/.openclaw-dev/openclaw.json"
@@ -38,14 +38,14 @@ if command -v node &>/dev/null; then
     const cfg = JSON.parse(fs.readFileSync('$OPENCLAW_JSON', 'utf8'));
     cfg.tools = cfg.tools || {};
     const allow = new Set(cfg.tools.alsoAllow || []);
-    allow.add('attest_query_receipts');
-    allow.add('attest_verify_chain');
+    allow.add('ar_query_receipts');
+    allow.add('ar_verify_chain');
     cfg.tools.alsoAllow = [...allow];
     fs.writeFileSync('$OPENCLAW_JSON', JSON.stringify(cfg, null, 2) + '\n');
   "
-  echo "Added attest tools to tools.alsoAllow"
+  echo "Added agent-receipts tools to tools.alsoAllow"
 else
-  echo "WARNING: node not found — manually add attest tools to tools.alsoAllow in $OPENCLAW_JSON"
+  echo "WARNING: node not found — manually add agent-receipts tools to tools.alsoAllow in $OPENCLAW_JSON"
 fi
 
 echo ""
@@ -55,7 +55,7 @@ $OPENCLAW --dev plugins list
 echo ""
 echo "=== 3b. Clearing old sessions and receipts for clean run ==="
 rm -rf ~/.openclaw-dev/agents/main/sessions/*
-rm -f ~/.openclaw/attest/receipts.db
+rm -f ~/.openclaw/agent-receipts/receipts.db
 
 echo ""
 echo "=== 4. Starting gateway in background ==="
@@ -65,7 +65,7 @@ sleep 5  # give gateway time to start
 
 echo ""
 echo "=== 5. Triggering tool calls + querying receipts ==="
-$OPENCLAW --dev agent --agent main --message "List the files in /tmp. Then use the attest_query_receipts tool to show me the audit trail, and finally use attest_verify_chain to verify the chain integrity."
+$OPENCLAW --dev agent --agent main --message "List the files in /tmp. Then use the ar_query_receipts tool to show me the audit trail, and finally use ar_verify_chain to verify the chain integrity."
 
 echo ""
 echo "=== 6. Shutting down gateway ==="
@@ -73,4 +73,4 @@ kill $GATEWAY_PID 2>/dev/null || true
 wait $GATEWAY_PID 2>/dev/null || true
 
 echo ""
-echo "=== Done! Check ~/.openclaw/attest/ for receipts.db ==="
+echo "=== Done! Check ~/.openclaw/agent-receipts/ for receipts.db ==="

--- a/src/classify.test.ts
+++ b/src/classify.test.ts
@@ -114,7 +114,7 @@ describe("loadCustomMappings", () => {
   });
 
   it("overrides default mappings with custom ones", () => {
-    tempDir = join(tmpdir(), `attest-taxonomy-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-taxonomy-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const taxPath = join(tempDir, "taxonomy.json");
 
@@ -133,7 +133,7 @@ describe("loadCustomMappings", () => {
   });
 
   it("preserves default mappings for tools not in custom file", () => {
-    tempDir = join(tmpdir(), `attest-taxonomy-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-taxonomy-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const taxPath = join(tempDir, "taxonomy.json");
 
@@ -160,7 +160,7 @@ describe("loadCustomMappings", () => {
   });
 
   it("throws on malformed JSON", () => {
-    tempDir = join(tmpdir(), `attest-taxonomy-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-taxonomy-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const taxPath = join(tempDir, "taxonomy.json");
 
@@ -170,7 +170,7 @@ describe("loadCustomMappings", () => {
   });
 
   it("merges custom patterns with defaults", () => {
-    tempDir = join(tmpdir(), `attest-taxonomy-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-taxonomy-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const taxPath = join(tempDir, "taxonomy.json");
 
@@ -193,7 +193,7 @@ describe("loadCustomMappings", () => {
   });
 
   it("custom patterns override default patterns with same prefix", () => {
-    tempDir = join(tmpdir(), `attest-taxonomy-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-taxonomy-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const taxPath = join(tempDir, "taxonomy.json");
 
@@ -212,7 +212,7 @@ describe("loadCustomMappings", () => {
   });
 
   it("works when custom file has no patterns field", () => {
-    tempDir = join(tmpdir(), `attest-taxonomy-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-taxonomy-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const taxPath = join(tempDir, "taxonomy.json");
 
@@ -230,7 +230,7 @@ describe("loadCustomMappings", () => {
   });
 
   it("works when custom file has only patterns (no mappings)", () => {
-    tempDir = join(tmpdir(), `attest-taxonomy-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-taxonomy-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const taxPath = join(tempDir, "taxonomy.json");
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -149,7 +149,7 @@ describe("parseCliArgs", () => {
 describe("helpText", () => {
   it("includes usage information", () => {
     const text = helpText();
-    expect(text).toContain("openclaw-attest");
+    expect(text).toContain("openclaw-agent-receipts");
     expect(text).toContain("receipts");
     expect(text).toContain("verify");
     expect(text).toContain("export");
@@ -352,7 +352,7 @@ describe("run", () => {
 
   it("outputs help text with --help", () => {
     run(["--help"]);
-    expect(stdoutData).toContain("openclaw-attest");
+    expect(stdoutData).toContain("openclaw-agent-receipts");
     expect(stdoutData).toContain("receipts");
     expect(stdoutData).toContain("verify");
     expect(stdoutData).toContain("export");
@@ -360,7 +360,7 @@ describe("run", () => {
 
   it("outputs version with --version", () => {
     run(["--version"]);
-    expect(stdoutData).toContain("openclaw-attest v");
+    expect(stdoutData).toContain("openclaw-agent-receipts v");
   });
 
   it("throws on unknown command", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 
 /**
- * Receipt Explorer CLI for openclaw-attest.
+ * Receipt Explorer CLI for openclaw-agent-receipts.
  *
  * Query and verify the SQLite receipt database outside of the agent.
  * Useful for auditing and debugging.
  *
  * Usage:
- *   openclaw-attest receipts [--risk <level>] [--action <type>] [--status <status>] [--limit <n>] [--db <path>] [--json]
- *   openclaw-attest verify [--chain <id>] [--db <path>] [--json]
- *   openclaw-attest export [--chain <id>] [--id <receipt-id>] [--format receipt|presentation] [--db <path>]
- *   openclaw-attest --help
- *   openclaw-attest --version
+ *   openclaw-agent-receipts receipts [--risk <level>] [--action <type>] [--status <status>] [--limit <n>] [--db <path>] [--json]
+ *   openclaw-agent-receipts verify [--chain <id>] [--db <path>] [--json]
+ *   openclaw-agent-receipts export [--chain <id>] [--id <receipt-id>] [--format receipt|presentation] [--db <path>]
+ *   openclaw-agent-receipts --help
+ *   openclaw-agent-receipts --version
  */
 
 import { parseArgs } from "node:util";
@@ -58,7 +58,7 @@ const VALID_RISK_LEVELS = new Set<string>(["low", "medium", "high", "critical"])
 const VALID_STATUSES = new Set<string>(["success", "failure", "pending"]);
 const VALID_FORMATS = new Set<string>(["receipt", "presentation"]);
 
-const DEFAULT_DB_PATH = "~/.openclaw/attest/receipts.db";
+const DEFAULT_DB_PATH = "~/.openclaw/agent-receipts/receipts.db";
 const DEFAULT_LIMIT = 20;
 
 // ---------------------------------------------------------------------------
@@ -101,21 +101,21 @@ function loadVersion(): string {
 // ---------------------------------------------------------------------------
 
 export function helpText(): string {
-  return `openclaw-attest — Receipt Explorer CLI
+  return `openclaw-agent-receipts — Receipt Explorer CLI
 
 Usage:
-  openclaw-attest receipts [options]   Query receipts from the audit trail
-  openclaw-attest verify  [options]    Verify chain integrity
-  openclaw-attest export  [options]    Export receipts as JSON-LD
-  openclaw-attest --help               Show this help
-  openclaw-attest --version            Show version
+  openclaw-agent-receipts receipts [options]   Query receipts from the audit trail
+  openclaw-agent-receipts verify  [options]    Verify chain integrity
+  openclaw-agent-receipts export  [options]    Export receipts as JSON-LD
+  openclaw-agent-receipts --help               Show this help
+  openclaw-agent-receipts --version            Show version
 
 receipts options:
   --risk <level>     Filter by risk level (low, medium, high, critical)
   --action <type>    Filter by action type (e.g. filesystem.file.read)
   --status <status>  Filter by outcome (success, failure, pending)
   --limit <n>        Max results (default: 20)
-  --db <path>        Override database path (default: ~/.openclaw/attest/receipts.db)
+  --db <path>        Override database path (default: ~/.openclaw/agent-receipts/receipts.db)
   --json             Output as JSON
 
 verify options:
@@ -532,7 +532,7 @@ export function run(argv: string[]): void {
       break;
 
     case "version":
-      process.stdout.write(`openclaw-attest v${loadVersion()}\n`);
+      process.stdout.write(`openclaw-agent-receipts v${loadVersion()}\n`);
       break;
 
     case "receipts":

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -9,8 +9,8 @@ describe("resolveConfig", () => {
   it("returns defaults when no config provided", () => {
     const cfg = resolveConfig();
 
-    expect(cfg.dbPath).toContain(".openclaw/attest/receipts.db");
-    expect(cfg.keyPath).toContain(".openclaw/attest/keys.json");
+    expect(cfg.dbPath).toContain(".openclaw/agent-receipts/receipts.db");
+    expect(cfg.keyPath).toContain(".openclaw/agent-receipts/keys.json");
     expect(cfg.taxonomyPath).toBeUndefined();
     expect(cfg.enabled).toBe(true);
   });
@@ -69,7 +69,7 @@ describe("loadOrCreateKeys", () => {
   });
 
   it("generates and persists keys when file does not exist", () => {
-    tempDir = join(tmpdir(), `attest-test-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-test-${randomUUID()}`);
     const keyPath = join(tempDir, "keys.json");
 
     const keys = loadOrCreateKeys(keyPath);
@@ -85,7 +85,7 @@ describe("loadOrCreateKeys", () => {
   });
 
   it("loads existing keys from file", () => {
-    tempDir = join(tmpdir(), `attest-test-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-test-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const keyPath = join(tempDir, "keys.json");
 
@@ -104,7 +104,7 @@ describe("loadOrCreateKeys", () => {
   });
 
   it("adds default verificationMethod if missing from stored file", () => {
-    tempDir = join(tmpdir(), `attest-test-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-test-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const keyPath = join(tempDir, "keys.json");
 
@@ -116,7 +116,7 @@ describe("loadOrCreateKeys", () => {
   });
 
   it("writes key file with restrictive permissions (owner-only)", () => {
-    tempDir = join(tmpdir(), `attest-test-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-test-${randomUUID()}`);
     const keyPath = join(tempDir, "keys.json");
 
     loadOrCreateKeys(keyPath);
@@ -127,7 +127,7 @@ describe("loadOrCreateKeys", () => {
   });
 
   it("tightens permissions on existing key files with insecure mode", () => {
-    tempDir = join(tmpdir(), `attest-test-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-test-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
     const keyPath = join(tempDir, "keys.json");
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,8 +10,8 @@ export type AttestPluginConfig = {
 };
 
 const DEFAULTS = {
-  dbPath: "~/.openclaw/attest/receipts.db",
-  keyPath: "~/.openclaw/attest/keys.json",
+  dbPath: "~/.openclaw/agent-receipts/receipts.db",
+  keyPath: "~/.openclaw/agent-receipts/keys.json",
 };
 
 function expandHome(p: string): string {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -158,6 +158,6 @@ export async function afterToolCall(
   advanceChain(deps.chains, sessionKey, sessionId, hash);
 
   deps.logger.info(
-    `attest: receipt ${signed.id} (${classification.action_type}, ${classification.risk_level}) → chain ${chain.chainId} seq ${nextSequence}`,
+    `agent-receipts: receipt ${signed.id} (${classification.action_type}, ${classification.risk_level}) → chain ${chain.chainId} seq ${nextSequence}`,
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * openclaw-attest — Agent Receipts plugin for OpenClaw
+ * openclaw-agent-receipts — Agent Receipts plugin for OpenClaw
  *
  * Generates cryptographically signed, hash-linked action receipts
  * for every tool call the agent makes, creating a tamper-evident
@@ -18,7 +18,7 @@ import { resetChain, getChainId, type ChainsMap, type ChainState } from "./chain
 import { createQueryReceiptsToolFactory, createVerifyChainToolFactory } from "./tools.js";
 
 export default definePluginEntry({
-  id: "openclaw-attest",
+  id: "openclaw-agent-receipts",
   name: "Agent Receipts",
   description: "Cryptographically signed audit trail for agent actions",
 
@@ -26,7 +26,7 @@ export default definePluginEntry({
     const cfg = resolveConfig(api.pluginConfig);
 
     if (!cfg.enabled) {
-      api.logger.info("attest: plugin disabled via config");
+      api.logger.info("agent-receipts: plugin disabled via config");
       return;
     }
 
@@ -40,17 +40,17 @@ export default definePluginEntry({
       const custom = loadCustomMappings(cfg.taxonomyPath);
       mappings = custom.mappings;
       patterns = custom.patterns;
-      api.logger.info(`attest: loaded custom taxonomy from ${cfg.taxonomyPath}`);
+      api.logger.info(`agent-receipts: loaded custom taxonomy from ${cfg.taxonomyPath}`);
     }
 
     // Init signing keys (generate on first run)
     const keys = loadOrCreateKeys(cfg.keyPath);
-    api.logger.info(`attest: keys loaded from ${cfg.keyPath}`);
+    api.logger.info(`agent-receipts: keys loaded from ${cfg.keyPath}`);
 
     // Open receipt store
     mkdirSync(dirname(cfg.dbPath), { recursive: true });
     const store = openStore(cfg.dbPath);
-    api.logger.info(`attest: receipt store opened at ${cfg.dbPath}`);
+    api.logger.info(`agent-receipts: receipt store opened at ${cfg.dbPath}`);
 
     const agentId = api.id;
 
@@ -74,7 +74,7 @@ export default definePluginEntry({
       const sessionId = ctx.sessionId;
       resetChain(chains, sessionKey, sessionId);
       pending.clear();
-      api.logger.info(`attest: new chain for session ${sessionKey}`);
+      api.logger.info(`agent-receipts: new chain for session ${sessionKey}`);
     });
 
     // Capture tool call context before execution
@@ -91,7 +91,7 @@ export default definePluginEntry({
       try {
         await afterToolCall(event, ctx, hookDeps);
       } catch (err) {
-        api.logger.warn(`attest: receipt creation failed: ${String(err)}`);
+        api.logger.warn(`agent-receipts: receipt creation failed: ${String(err)}`);
       }
     });
 
@@ -106,26 +106,26 @@ export default definePluginEntry({
 
     // Register as factory functions (OpenClawPluginToolFactory pattern)
     api.registerTool(createQueryReceiptsToolFactory(toolDeps), {
-      name: "attest_query_receipts",
+      name: "ar_query_receipts",
     });
 
     api.registerTool(createVerifyChainToolFactory(toolDeps), {
-      name: "attest_verify_chain",
+      name: "ar_verify_chain",
     });
 
     // --- Service: clean up store on shutdown ---
 
     api.registerService({
-      id: "attest-store",
+      id: "ar-store",
       async start() {
         // Store is already opened during register — nothing to do
       },
       async stop() {
         store.close();
-        api.logger.info("attest: receipt store closed");
+        api.logger.info("agent-receipts: receipt store closed");
       },
     });
 
-    api.logger.info("attest: plugin registered — receipts will be generated for all tool calls");
+    api.logger.info("agent-receipts: plugin registered — receipts will be generated for all tool calls");
   },
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -99,7 +99,7 @@ describe("integration: full plugin lifecycle", () => {
   });
 
   function setupPlugin(configOverrides?: Record<string, unknown>) {
-    tempDir = join(tmpdir(), `attest-integration-${randomUUID()}`);
+    tempDir = join(tmpdir(), `ar-integration-${randomUUID()}`);
     mkdirSync(tempDir, { recursive: true });
 
     const config = {
@@ -130,12 +130,12 @@ describe("integration: full plugin lifecycle", () => {
     expect(hooks.has("after_tool_call")).toBe(true);
 
     // Two tools registered
-    expect(tools.has("attest_query_receipts")).toBe(true);
-    expect(tools.has("attest_verify_chain")).toBe(true);
+    expect(tools.has("ar_query_receipts")).toBe(true);
+    expect(tools.has("ar_verify_chain")).toBe(true);
 
     // One service registered
     expect(services).toHaveLength(1);
-    expect(services[0].id).toBe("attest-store");
+    expect(services[0].id).toBe("ar-store");
 
     // Logs confirm successful registration
     expect(logs.some((l) => l.includes("plugin registered"))).toBe(true);
@@ -167,7 +167,7 @@ describe("integration: full plugin lifecycle", () => {
     }
 
     // 3. Query receipts via the registered tool
-    const queryTool = tools.get("attest_query_receipts")!.definition;
+    const queryTool = tools.get("ar_query_receipts")!.definition;
     const queryResult = await queryTool.execute("tc-query", {});
     const queryData = JSON.parse(queryResult.content[0].text);
 
@@ -187,7 +187,7 @@ describe("integration: full plugin lifecycle", () => {
     expect(queryData.results[2].sequence).toBe(3);
 
     // 4. Verify chain integrity via the registered tool (resolve factory with session context)
-    const verifyFactory = tools.get("attest_verify_chain")!.factory!;
+    const verifyFactory = tools.get("ar_verify_chain")!.factory!;
     const verifyTool = verifyFactory(sessionCtx);
     const verifyResult = await verifyTool.execute("tc-verify", {});
 
@@ -229,7 +229,7 @@ describe("integration: full plugin lifecycle", () => {
     await fireHook(hooks, "after_tool_call", { ...event, result: { ok: true } }, session2);
 
     // Verify both chains independently (resolve factory per session)
-    const verifyFactory = tools.get("attest_verify_chain")!.factory!;
+    const verifyFactory = tools.get("ar_verify_chain")!.factory!;
 
     const r1 = await verifyFactory(session1).execute("v1", {});
     const d1 = JSON.parse(r1.content[1].text);
@@ -242,7 +242,7 @@ describe("integration: full plugin lifecycle", () => {
     expect(d2.length).toBe(1);
 
     // Session 2's receipt starts at sequence 1 (fresh chain)
-    const queryTool = tools.get("attest_query_receipts")!.definition;
+    const queryTool = tools.get("ar_query_receipts")!.definition;
     const qr = await queryTool.execute("q", { action_type: "filesystem.file.delete" });
     const qd = JSON.parse(qr.content[0].text);
     expect(qd.results[0].sequence).toBe(1);
@@ -269,7 +269,7 @@ describe("integration: full plugin lifecycle", () => {
       error: "Command failed with exit code 1",
     }, { sessionKey: "err", sessionId: "sid-err" });
 
-    const queryTool = tools.get("attest_query_receipts")!.definition;
+    const queryTool = tools.get("ar_query_receipts")!.definition;
     const result = await queryTool.execute("q", { status: "failure" });
     const data = JSON.parse(result.content[0].text);
 

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Shared test utilities for openclaw-attest tests.
+ * Shared test utilities for openclaw-agent-receipts tests.
  */
 
 import {

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -4,7 +4,7 @@ import { createQueryReceiptsTool, createVerifyChainTool, createVerifyChainToolFa
 import { makeHookDeps, simulateToolCall } from "./test-helpers.js";
 import { getChainId } from "./chain.js";
 
-describe("attest_query_receipts", () => {
+describe("ar_query_receipts", () => {
   let store: ReceiptStore;
   let deps: ReturnType<typeof makeHookDeps>;
   let tool: ReturnType<typeof createQueryReceiptsTool>;
@@ -125,7 +125,7 @@ describe("attest_query_receipts", () => {
   });
 });
 
-describe("attest_verify_chain", () => {
+describe("ar_verify_chain", () => {
   let store: ReceiptStore;
   let deps: ReturnType<typeof makeHookDeps>;
   let tool: ReturnType<typeof createVerifyChainTool>;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -29,12 +29,12 @@ type ToolFactoryContext = {
 };
 
 /**
- * Create a factory function for the attest_query_receipts tool.
+ * Create a factory function for the ar_query_receipts tool.
  * The factory is called by OpenClaw at runtime with session context.
  */
 export function createQueryReceiptsToolFactory(deps: ToolDeps) {
   return (_ctx: ToolFactoryContext) => ({
-    name: "attest_query_receipts",
+    name: "ar_query_receipts",
     label: "Query Attestation Receipts",
     description:
       "Search the cryptographic audit trail of actions taken in this session. " +
@@ -104,12 +104,12 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
 }
 
 /**
- * Create a factory function for the attest_verify_chain tool.
+ * Create a factory function for the ar_verify_chain tool.
  * The factory captures session context from OpenClaw at runtime.
  */
 export function createVerifyChainToolFactory(deps: ToolDeps) {
   return (ctx: ToolFactoryContext) => ({
-    name: "attest_verify_chain",
+    name: "ar_verify_chain",
     label: "Verify Attestation Chain",
     description:
       "Cryptographically verify the integrity of the action receipt chain for a session. " +
@@ -163,7 +163,7 @@ export function createVerifyChainToolFactory(deps: ToolDeps) {
 // --- Legacy direct-tool creators (used by tests) ---
 
 /**
- * Create the attest_query_receipts tool definition (non-factory).
+ * Create the ar_query_receipts tool definition (non-factory).
  * @deprecated Use createQueryReceiptsToolFactory for OpenClaw integration.
  */
 export function createQueryReceiptsTool(deps: ToolDeps) {
@@ -171,7 +171,7 @@ export function createQueryReceiptsTool(deps: ToolDeps) {
 }
 
 /**
- * Create the attest_verify_chain tool definition (non-factory).
+ * Create the ar_verify_chain tool definition (non-factory).
  * @deprecated Use createVerifyChainToolFactory for OpenClaw integration.
  */
 export function createVerifyChainTool(deps: ToolDeps) {


### PR DESCRIPTION
## Summary
Complete rename of all internal "attest" identifiers, now that we're pre-v1 with no external users:

- **Plugin ID**: `openclaw-attest` → `openclaw-agent-receipts`
- **CLI binary**: `openclaw-attest` → `openclaw-agent-receipts`
- **Tool names**: `attest_query_receipts` → `ar_query_receipts`, `attest_verify_chain` → `ar_verify_chain`
- **File paths**: `~/.openclaw/attest/` → `~/.openclaw/agent-receipts/`
- **Log prefix**: `attest:` → `agent-receipts:`
- **Service ID**: `attest-store` → `ar-store`
- **Test temp dirs**: `attest-*` → `ar-*`

All 116 tests pass, typecheck clean.

## Test plan
- [x] `pnpm test` — 116/116 passing
- [x] `pnpm typecheck` — clean