### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 0.3.0 for npm publish

Breaking changes since 0.2.0:
- Plugin ID: `openclaw-attest` → `openclaw-agent-receipts`
- CLI binary: `openclaw-attest` → `openclaw-agent-receipts`
- Tool names: `attest_query_receipts` → `ar_query_receipts`, `attest_verify_chain` → `ar_verify_chain`
- File paths: `~/.openclaw/attest/` → `~/.openclaw/agent-receipts/`
- Branding: "Attest Protocol" → "Agent Receipts" everywhere

## Test plan
- [x] Merge, then create GitHub release `v0.3.0` to trigger npm publish