### PR TITLE
Skip version tag check on workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Verify release tag matches package.json version
+        if: github.event_name == 'release'
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
           TAG_VERSION="${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
## Summary
- Add `if: github.event_name == 'release'` guard to the version check step, matching the ar monorepo's publish-ts.yml

Without this, `workflow_dispatch` always fails because `GITHUB_REF_NAME` is `main`, not a version tag.

## Test plan
- [x] Merge, then re-trigger: `gh workflow run publish.yml`