### PR TITLE
Add Claude Code hooks for deterministic guardrails

### DIFF
--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Lint TypeScript files after Claude edits them.
+# Exit 0: linting passed (or not applicable). Exit 2: linting failed.
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "lint-on-edit: jq is not installed; skipping lint hook" >&2
+  exit 0
+fi
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+if [[ "$FILE_PATH" == *.ts || "$FILE_PATH" == *.js ]]; then
+  cd "${CLAUDE_PROJECT_DIR:-.}"
+  if pnpm exec biome --version >/dev/null 2>&1; then
+    pnpm exec biome check "$FILE_PATH" >&2 || { echo "biome: $FILE_PATH has issues" >&2; exit 2; }
+  else
+    echo "lint-on-edit: biome not installed; skipping lint for $FILE_PATH" >&2
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/test-before-push.sh
+++ b/.claude/hooks/test-before-push.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run typecheck and tests before git push.
+# Exit 0: all passed. Exit 2: failed.
+
+set -Eeuo pipefail
+
+fail() {
+  echo "$1" >&2
+  exit 2
+}
+
+trap 'fail "Hook failed unexpectedly — fix before pushing."' ERR
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || fail "Failed to enter project directory."
+
+echo "Running typecheck..." >&2
+pnpm run typecheck >&2 || fail "Typecheck failed — fix before pushing."
+
+echo "Running tests..." >&2
+pnpm test >&2 || fail "Tests failed — fix before pushing."
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lint-on-edit.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "if": "Bash(git push*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/test-before-push.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with two hooks:
  - **PostToolUse** (Write|Edit): runs biome check after every file edit
  - **PreToolUse** (Bash `git push`): runs typecheck and tests before push
- Hook scripts in `.claude/hooks/` — lint-on-edit.sh and test-before-push.sh
- Unlike AGENTS.md rules which are advisory, hooks always execute deterministically

Closes #67