### PR TITLE
Add shellcheck to Claude Code lint hook and CI

### DIFF
--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -16,7 +16,14 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-if [[ "$FILE_PATH" == *.ts || "$FILE_PATH" == *.js ]]; then
+if [[ "$FILE_PATH" == *.sh ]]; then
+  cd "${CLAUDE_PROJECT_DIR:-.}"
+  if command -v shellcheck >/dev/null 2>&1; then
+    shellcheck "$FILE_PATH" >&2 || { echo "shellcheck: $FILE_PATH has issues" >&2; exit 2; }
+  else
+    echo "lint-on-edit: shellcheck not installed; skipping lint for $FILE_PATH" >&2
+  fi
+elif [[ "$FILE_PATH" == *.ts || "$FILE_PATH" == *.js ]]; then
   cd "${CLAUDE_PROJECT_DIR:-.}"
   if pnpm exec biome --version >/dev/null 2>&1; then
     pnpm exec biome check "$FILE_PATH" >&2 || { echo "biome: $FILE_PATH has issues" >&2; exit 2; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Shellcheck
+        run: find . -name '*.sh' -not -path './.git/*' -not -path './node_modules/*' -print0 | xargs -0 --no-run-if-empty shellcheck
+
       - run: pnpm run typecheck
 
       - run: pnpm test


### PR DESCRIPTION
## Summary
- Adds `*.sh` handling to Claude Code lint-on-edit hook (graceful skip if not installed)
- Adds `Shellcheck` step to CI workflow — hard-fails on shellcheck violations
- Two layers: Claude Code hook (agent edits), CI (enforced)

Verified: all `.claude/hooks/*.sh` scripts pass `shellcheck` as-is.