### PR TITLE
chore: add Conventional Commits enforcement via Lefthook and convco

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,27 @@ pnpm install
 - Vitest for all tests; cover edge cases
 - Never push directly to `main`
 
+## Commit messages
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/). Every commit message must start with a type:
+
+```
+feat: add new feature
+fix: correct a bug
+docs: update documentation
+chore: maintenance task
+refactor: restructure without behavior change
+test: add or update tests
+ci: change CI/CD configuration
+```
+
+The `commit-msg` hook enforces this via [convco](https://convco.github.io/). Install hooks with:
+
+```bash
+brew install lefthook convco
+lefthook install
+```
+
 ## Taxonomy Contributions
 
 Adding mappings for new OpenClaw tools is a great way to contribute. Edit `taxonomy.json` and add corresponding tests in `src/classify.test.ts`.
@@ -72,6 +93,7 @@ Before opening a PR, verify:
 - [ ] No real keys or secrets in the diff — use test fixtures only
 - [ ] Taxonomy changes include corresponding tests in `src/classify.test.ts`
 - [ ] AGENTS.md updated if you changed project structure
+- [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/) format
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,12 +57,15 @@ test: add or update tests
 ci: change CI/CD configuration
 ```
 
-The `commit-msg` hook enforces this via [convco](https://convco.github.io/). Install hooks with:
+The `commit-msg` hook enforces this via [convco](https://convco.github.io/check/). Install hooks with:
 
 ```bash
-brew install lefthook convco
+brew install lefthook convco          # macOS
+cargo install convco                  # Linux / Windows / any platform with Rust
 lefthook install
 ```
+
+See the [convco installation docs](https://convco.github.io/check/installation/) for all options.
 
 ## Taxonomy Contributions
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,19 @@
+# Lefthook — pre-commit and commit-msg hooks
+# Install: brew install lefthook && lefthook install
+# Docs: https://lefthook.dev/configuration/
+
+pre-commit:
+  parallel: true
+  jobs:
+    - name: typecheck
+      glob: "*.{ts,tsx}"
+      run: pnpm run typecheck
+
+    - name: test
+      glob: "*.{ts,tsx}"
+      run: pnpm test
+
+commit-msg:
+  commands:
+    conventional-commit:
+      run: convco check --from-stdin < {1}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,14 +6,14 @@ pre-commit:
   parallel: true
   jobs:
     - name: typecheck
-      glob: "*.{ts,tsx}"
+      glob: "*.{ts,tsx,json}"
       run: pnpm run typecheck
 
     - name: test
-      glob: "*.{ts,tsx}"
+      glob: "*.{ts,tsx,json}"
       run: pnpm test
 
 commit-msg:
   commands:
     conventional-commit:
-      run: convco check --from-stdin < {1}
+      run: convco check --from-stdin < "{1}"


### PR DESCRIPTION
## Summary

- Adds Lefthook configuration with pre-commit (typecheck, test) and commit-msg hooks
- Enforces Conventional Commits format via convco
- Documents commit message convention in CONTRIBUTING.md

Companion PRs: agent-receipts/ar and agent-receipts/dashboard

## Test plan

- [x] `lefthook install` sets up hooks correctly
- [x] `convco check` rejects non-conventional messages
- [x] Pre-commit hooks run typecheck and tests on staged .ts files