### PR TITLE
fix: add explicit node types for TypeScript 6 compatibility

### DIFF
--- a/.claude/hooks/test-before-push.sh
+++ b/.claude/hooks/test-before-push.sh
@@ -13,8 +13,8 @@ trap 'fail "Hook failed unexpectedly — fix before pushing."' ERR
 
 # Only run for git push commands.
 input=$(cat)
-command=$(echo "$input" | grep -o '"command":"[^"]*"' | head -1 | sed 's/"command":"//;s/"//')
-if [[ "$command" != git\ push* ]]; then
+command=$(printf '%s' "$input" | jq -r '.command // empty' 2>/dev/null || printf '')
+if [[ -z "$command" ]] || [[ "$command" != git\ push* ]]; then
   exit 0
 fi
 

--- a/.claude/hooks/test-before-push.sh
+++ b/.claude/hooks/test-before-push.sh
@@ -11,6 +11,13 @@ fail() {
 
 trap 'fail "Hook failed unexpectedly — fix before pushing."' ERR
 
+# Only run for git push commands.
+input=$(cat)
+command=$(echo "$input" | grep -o '"command":"[^"]*"' | head -1 | sed 's/"command":"//;s/"//')
+if [[ "$command" != git\ push* ]]; then
+  exit 0
+fi
+
 cd "${CLAUDE_PROJECT_DIR:-.}" || fail "Failed to enter project directory."
 
 echo "Running typecheck..." >&2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": ".",
     "declaration": true


### PR DESCRIPTION
## Summary

- TypeScript 6.0 (bumped in #79) no longer auto-includes `@types/node` with `NodeNext` module resolution
- Adds `"types": ["node"]` to `tsconfig.json` to explicitly declare Node.js types
- Also fixes a hook misconfiguration where `test-before-push.sh` was running before every bash command instead of only `git push`

## Test plan

- [x] `pnpm run typecheck` passes locally
- [x] CI passes on this PR
- [x] After merging, #79 should pass CI