### PR TITLE
fix: point openclaw.extensions at compiled dist entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./src/index.ts"
+      "./dist/src/index.js"
     ]
   }
 }


### PR DESCRIPTION
## Problem

`openclaw plugins install @agnt-rcpt/openclaw` fails with:

```
extension entry not found: ./src/index.ts
```

The `openclaw.extensions` field in `package.json` pointed at the TypeScript source:

```json
"openclaw": {
  "extensions": ["./src/index.ts"]
}
```

But `./src/index.ts` is never included in the published package — the `files` array only ships `dist/`, `taxonomy.json`, and `openclaw.plugin.json`. The loader reads the field, can't find the file, and fails.

## Fix

Point `openclaw.extensions` at the compiled entry that's actually shipped:

```json
"openclaw": {
  "extensions": ["./dist/src/index.js"]
}
```

## Needs

A patch release (`0.3.1`) to unblock installation from npm.