### PR TITLE
chore: release 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump to `0.3.1` to ship the fix from #85 (`openclaw.extensions` pointing at the wrong entry point).

**After merging:** create a `v0.3.1` GitHub Release to trigger the publish workflow → npm.