### PR TITLE
chore: release 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Version bump to `0.3.2` to ship the bug fix from #94 (closes #93): SDK 0.4.1 bump fixes silent receipt write failures caused by `outcome.error` being set to `undefined` (invalid per RFC 8785).

**After merging:** create a `v0.3.2` GitHub Release to trigger the publish workflow → npm.