### PR TITLE
fix: CLI always runs when invoked via npx/symlink (v0.3.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,6 @@
 
 import { parseArgs } from "node:util";
 import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import { readFileSync } from "node:fs";
 import { openStore, verifyStoredChain } from "@agnt-rcpt/sdk-ts";
 import type { ActionReceipt, RiskLevel, OutcomeStatus, ReceiptStore, StoreStats } from "@agnt-rcpt/sdk-ts";
@@ -565,16 +564,9 @@ export function run(argv: string[]): void {
   }
 }
 
-// Entry point when run as a script
-const isDirectRun =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === resolve(process.argv[1]);
-
-if (isDirectRun) {
-  try {
-    run(process.argv.slice(2));
-  } catch (err) {
-    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exitCode = 1;
-  }
+try {
+  run(process.argv.slice(2));
+} catch (err) {
+  process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exitCode = 1;
 }


### PR DESCRIPTION
## Problem

Running the CLI via `npx` produced no output. `path.resolve()` does not follow symlinks, so when npx invoked the bin via a symlink, `fileURLToPath(import.meta.url) === resolve(process.argv[1])` was always `false` — `run()` was never called.

Running the compiled `dist/src/cli.js` directly with `node` worked fine.

## Fix

Remove the `isDirectRun` guard entirely. `src/cli.ts` is a CLI entrypoint, not a shared library — unconditional execution at the module boundary is correct and removes an entire class of symlink/path-resolution bugs.

Also removes the now-unused `fileURLToPath` import.

## Changes

- `src/cli.ts` — drop `isDirectRun` check and `fileURLToPath` import; entry block now runs unconditionally
- `package.json` — bump version to 0.3.3

## Test plan

- [ ] `pnpm test` — 116 tests pass
- [ ] `pnpm run typecheck` — clean
- [ ] `pnpm build` — clean
- [ ] `npx openclaw-agent-receipts --version` prints version after install (manual)