### PR TITLE
chore: bump @agnt-rcpt/sdk-ts to ^0.5.0, drop ActionWithPreview bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- **Parameter preview** — opt-in selective disclosure of action parameters in receipts.
+  Configure via `parameterPreview: true | "high" | string[] | false` (default `false`).
+  When enabled, specific named fields (e.g. `command`, `path`, `url`) are stored verbatim
+  in `parameters_preview` alongside the existing SHA-256 parameters hash.
+
+### Changed
+- Bump `@agnt-rcpt/sdk-ts` to `^0.5.0`, which adds `parameters_preview` natively to the
+  `Action` type. The local `ActionWithPreview` bridge type has been removed.
+
+## [0.3.3] - 2026-04-27
+
+### Fixed
+- CLI entrypoint is now always invoked via the `openclaw-agent-receipts` bin regardless of
+  invocation path (#97).
+
+## [0.3.2] - 2026-04-27
+
+### Changed
+- Bump `@agnt-rcpt/sdk-ts` to `0.4.1`.
+- Add `CLAUDE.md` (imports `AGENTS.md`) for Claude Code IDE integration (#88).
+
+### Fixed
+- Assert `error` key absent on success path in receipt outcome tests (#94).
+
+## [0.3.1] - 2026-04-27
+
+### Changed
+- Bump `@agnt-rcpt/sdk-ts` to `^0.4.0` (#82).
+- Require Node.js `>=22.11.0` to match SDK peer requirement.
+- SHA-pin all GitHub Actions for supply chain security (#76).
+- Add Dependabot config for automated dependency and Actions updates (#77).
+- Add Conventional Commits enforcement via Lefthook and convco (#75).
+
+### Fixed
+- `openclaw.extensions` entry now points at the compiled `dist/` entry, not source (#85).
+
+## [0.3.0] - 2026-04-03
+
+### Changed
+- Renamed package scope and all identifiers from `attest-protocol` to `agent-receipts` /
+  `@agnt-rcpt`. Package is now `@agnt-rcpt/openclaw` (#43–#48).
+- Upgrade Node.js runtime from 22 to 24 in CI (#52).
+- Workflow dispatch no longer requires a version tag (#51).
+
+### Added
+- Security guidelines, agent safety rules, and GitHub issue/PR templates (#54).
+- Comprehensive `AGENTS.md` with contribution guidelines, mindset rules, and agent
+  safety constraints (#61–#71).
+
+## [0.2.0] - 2026-04-01
+
+### Added
+- Pattern-based auto-classification: tool names not in the exact-match taxonomy fall
+  back to regex patterns (#34).
+- JSON-LD receipt export (#33).
+- `openclaw-agent-receipts` CLI for receipt exploration (#32).
+- `AGENTS.md` for multi-agent IDE support (#31).
+- Factory pattern for agent tools; deterministic service lifecycle (#28).
+- Full taxonomy of OpenClaw built-in tools.
+- Integration smoke test covering the complete plugin lifecycle (#25).
+
+### Changed
+- All mutable state now flows through `HookDeps` — no module-level singletons,
+  making multiple plugin instances safe (#23).
+
+### Fixed
+- Security hardening: key file permissions, input validation, pending-map memory
+  leak prevention (#22).
+
+[Unreleased]: https://github.com/agent-receipts/openclaw/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/agent-receipts/openclaw/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/agent-receipts/openclaw/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/agent-receipts/openclaw/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/agent-receipts/openclaw/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/agent-receipts/openclaw/releases/tag/v0.2.0

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@agnt-rcpt/sdk-ts": "^0.4.1",
+    "@agnt-rcpt/sdk-ts": "^0.5.0",
     "@sinclair/typebox": "0.34.49"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@agnt-rcpt/sdk-ts':
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.5.0
+        version: 0.5.0
       '@sinclair/typebox':
         specifier: 0.34.49
         version: 0.34.49
@@ -38,8 +38,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@agnt-rcpt/sdk-ts@0.4.1':
-    resolution: {integrity: sha512-V1a3uH1D/78Em/peFP+APLF/Is0+ZqQ8QEuYppbazUuLuINp2g2Q+q2DF2pQooFfXELUhsor9VJMseRoMsH+Cg==}
+  '@agnt-rcpt/sdk-ts@0.5.0':
+    resolution: {integrity: sha512-74JZAvX/VauEwk/TBGIE4RXiWMJOvGLgaE5iTUXFe3BZ0zvvNkK1eBOVk7IFOp8Pp1xI1pe8iVUNc7jFvJmdUg==}
     engines: {node: '>=22.11.0'}
 
   '@anthropic-ai/sdk@0.90.0':
@@ -2521,7 +2521,7 @@ snapshots:
     dependencies:
       zod: 4.3.6
 
-  '@agnt-rcpt/sdk-ts@0.4.1': {}
+  '@agnt-rcpt/sdk-ts@0.5.0': {}
 
   '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
     dependencies:

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -51,11 +51,6 @@ export type HookDeps = {
   parameterPreview?: ParameterPreviewConfig;
 };
 
-// sdk-ts@0.5.0 will add parameters_preview to Action; this local bridge can be removed then.
-type ActionWithPreview = Omit<Action, "id" | "timestamp"> & {
-  parameters_preview?: Record<string, string>;
-};
-
 export function shouldPreview(
   config: ParameterPreviewConfig | undefined,
   riskLevel: string,
@@ -171,7 +166,7 @@ export async function afterToolCall(
   // Determine outcome
   const status = event.error ? "failure" as const : "success" as const;
 
-  const action: ActionWithPreview = {
+  const action: Omit<Action, "id" | "timestamp"> = {
     type: classification.action_type,
     risk_level: classification.risk_level,
     target: { system: "openclaw", resource: event.toolName },

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -15,9 +15,6 @@ import { openStore } from "@agnt-rcpt/sdk-ts";
 import type { OpenClawPluginApi } from "./openclaw-types.js";
 import plugin from "./index.js";
 
-// Local extension until sdk-ts@0.5.0 adds parameters_preview to Action.
-type ActionWithPreview = { parameters_preview?: Record<string, string> };
-
 // ---- Mock OpenClawPluginApi ----
 
 type CapturedHook = {
@@ -307,11 +304,11 @@ describe("integration: full plugin lifecycle", () => {
         expect(chain).toHaveLength(2);
 
         // bash receipt (high risk) should have parameters_preview with first matching field
-        const bashAction = chain[0]!.credentialSubject.action as typeof chain[0]["credentialSubject"]["action"] & ActionWithPreview;
+        const bashAction = chain[0]!.credentialSubject.action;
         expect(bashAction.parameters_preview).toEqual({ command: "ls -la" });
 
         // read_file receipt (low risk) should NOT have parameters_preview
-        const readAction = chain[1]!.credentialSubject.action as typeof chain[1]["credentialSubject"]["action"] & ActionWithPreview;
+        const readAction = chain[1]!.credentialSubject.action;
         expect(readAction.parameters_preview).toBeUndefined();
 
         // Chain must still be cryptographically valid with parameters_preview present
@@ -343,7 +340,7 @@ describe("integration: full plugin lifecycle", () => {
         const chain = readStore.getChain("chain_openclaw_no-preview_sid-np");
         expect(chain).toHaveLength(1);
 
-        const action = chain[0]!.credentialSubject.action as typeof chain[0]["credentialSubject"]["action"] & ActionWithPreview;
+        const action = chain[0]!.credentialSubject.action;
         expect(action.parameters_preview).toBeUndefined();
       } finally {
         readStore.close();
@@ -372,11 +369,11 @@ describe("integration: full plugin lifecycle", () => {
         expect(chain).toHaveLength(2);
 
         // read_file previews path (first of ["path", "file_path", "filename"])
-        const readAction = chain[0]!.credentialSubject.action as typeof chain[0]["credentialSubject"]["action"] & ActionWithPreview;
+        const readAction = chain[0]!.credentialSubject.action;
         expect(readAction.parameters_preview).toEqual({ path: "/docs/readme.md" });
 
         // edit_file has no preview_fields in taxonomy — no parameters_preview
-        const editAction = chain[1]!.credentialSubject.action as typeof chain[1]["credentialSubject"]["action"] & ActionWithPreview;
+        const editAction = chain[1]!.credentialSubject.action;
         expect(editAction.parameters_preview).toBeUndefined();
       } finally {
         readStore.close();
@@ -404,10 +401,10 @@ describe("integration: full plugin lifecycle", () => {
         const chain = readStore.getChain("chain_openclaw_preview-arr_sid-arr");
         expect(chain).toHaveLength(2);
 
-        const bashAction = chain[0]!.credentialSubject.action as typeof chain[0]["credentialSubject"]["action"] & ActionWithPreview;
+        const bashAction = chain[0]!.credentialSubject.action;
         expect(bashAction.parameters_preview).toEqual({ command: "echo hello" });
 
-        const readAction = chain[1]!.credentialSubject.action as typeof chain[1]["credentialSubject"]["action"] & ActionWithPreview;
+        const readAction = chain[1]!.credentialSubject.action;
         expect(readAction.parameters_preview).toBeUndefined();
       } finally {
         readStore.close();


### PR DESCRIPTION
## Summary

- Bumps `@agnt-rcpt/sdk-ts` from `^0.4.1` to `^0.5.0`
- Removes the local `ActionWithPreview` bridge type from `src/hooks.ts` and `src/integration.test.ts` — sdk-ts@0.5.0 now includes `parameters_preview?: Record<string, string>` natively on the `Action` type, making the bridge obsolete
- Adds `CHANGELOG.md` covering all releases from v0.2.0 through current unreleased changes

## Test plan

- [ ] `pnpm test` — 146 tests pass
- [ ] `pnpm typecheck` — clean