### PR TITLE
fix: recover chain state from store after plugin restart

### DIFF
--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   openStore,
   verifyChain,
+  hashReceipt,
   canonicalize,
   sha256,
   type ReceiptStore,
@@ -172,6 +173,51 @@ describe("hooks", () => {
 
       const chain = store.getChain("chain_openclaw_test-session_sid-1");
       expect(chain[0]!.credentialSubject.action.type).toBe("unknown");
+    });
+  });
+
+  describe("chain recovery after plugin restart", () => {
+    it("resumes sequence and links chain correctly after in-memory state is lost", async () => {
+      // Populate the store with two receipts
+      await simulateToolCall(deps, "read_file", { path: "/a.txt" }, { toolCallId: "tc-1" });
+      await simulateToolCall(deps, "read_file", { path: "/b.txt" }, { toolCallId: "tc-2" });
+
+      // Simulate restart: same key reloaded from disk, in-memory chain state wiped
+      deps.chains.clear();
+
+      // Before this fix: threw UNIQUE constraint failed (receipts.chain_id, receipts.sequence)
+      await simulateToolCall(deps, "read_file", { path: "/c.txt" }, { toolCallId: "tc-3" });
+
+      const chain = store.getChain("chain_openclaw_test-session_sid-1");
+      expect(chain).toHaveLength(3);
+      expect(chain[2]!.credentialSubject.chain.sequence).toBe(3);
+      expect(chain[2]!.credentialSubject.chain.previous_receipt_hash).toBe(hashReceipt(chain[1]!));
+
+      // All three receipts form a valid cryptographic chain under the same key
+      const verification = verifyChain(chain, deps.publicKey);
+      expect(verification.valid).toBe(true);
+      expect(verification.length).toBe(3);
+    });
+
+    it("does not re-trigger recovery on calls after the first post-restart call", async () => {
+      await simulateToolCall(deps, "read_file", { path: "/a.txt" }, { toolCallId: "tc-1" });
+      deps.chains.clear();
+      await simulateToolCall(deps, "read_file", { path: "/b.txt" }, { toolCallId: "tc-2" });
+      await simulateToolCall(deps, "read_file", { path: "/c.txt" }, { toolCallId: "tc-3" });
+
+      const chain = store.getChain("chain_openclaw_test-session_sid-1");
+      expect(chain).toHaveLength(3);
+      expect(chain[2]!.credentialSubject.chain.sequence).toBe(3);
+    });
+
+    it("starts at sequence 1 when the store has no prior receipts for the chain", async () => {
+      // Fresh store, fresh chains map — recovery should be a no-op
+      await simulateToolCall(deps, "read_file", { path: "/a.txt" });
+
+      const chain = store.getChain("chain_openclaw_test-session_sid-1");
+      expect(chain).toHaveLength(1);
+      expect(chain[0]!.credentialSubject.chain.sequence).toBe(1);
+      expect(chain[0]!.credentialSubject.chain.previous_receipt_hash).toBeNull();
     });
   });
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -19,7 +19,7 @@ import {
 } from "@agnt-rcpt/sdk-ts";
 
 import { classify, type ExtendedTaxonomyMapping, type TaxonomyPattern } from "./classify.js";
-import { type ChainsMap, getChainState, advanceChain } from "./chain.js";
+import { type ChainsMap, type ChainState, getChainState, advanceChain } from "./chain.js";
 import type { ParameterPreviewConfig } from "./config.js";
 
 export type PendingCall = {
@@ -36,6 +36,25 @@ const PENDING_MAX_SIZE = 1000;
 
 function callKey(runId?: string, toolCallId?: string): string {
   return `${runId ?? "unknown"}:${toolCallId ?? "unknown"}`;
+}
+
+/**
+ * If in-memory chain state is fresh (sequence=0, no prior hash), check the store
+ * for existing receipts and resume from the last one. Handles plugin restarts
+ * where the DB retains receipts but in-memory state is wiped.
+ */
+function recoverChainState(
+  state: ChainState,
+  store: ReceiptStore,
+  logger: { warn: (msg: string) => void },
+): void {
+  const last = store.getChain(state.chainId).at(-1);
+  if (!last) return;
+  state.sequence = last.credentialSubject.chain.sequence;
+  state.previousReceiptHash = hashReceipt(last);
+  logger.warn(
+    `agent-receipts: in-memory chain state was missing; recovered chain ${state.chainId} at sequence ${state.sequence}`,
+  );
 }
 
 export type HookDeps = {
@@ -159,8 +178,11 @@ export async function afterToolCall(
       ? extractPreview(previewParams, classification.preview_fields)
       : undefined;
 
-  // Get chain state and advance sequence
+  // Recover from the store if in-memory state was lost (e.g. plugin restart mid-session)
   const chain = getChainState(deps.chains, sessionKey, sessionId);
+  if (chain.sequence === 0 && chain.previousReceiptHash === null) {
+    recoverChainState(chain, deps.store, deps.logger);
+  }
   const nextSequence = chain.sequence + 1;
 
   // Determine outcome


### PR DESCRIPTION
## What

Fixes a production bug where all receipt creation fails with `UNIQUE constraint failed: receipts.chain_id, receipts.sequence` after a plugin restart.

## Root cause

When the plugin process restarts mid-session, the in-memory `chains` Map is wiped but SQLite retains all prior receipts. OpenClaw resumes the existing session without re-firing `session_start`, so the chain re-initialises at `sequence=0`. The first tool call computes `nextSequence=1`, which already exists in the DB — `store.insert()` throws synchronously. Because `advanceChain` is called _after_ the insert, it is never reached: the sequence stays stuck at 0 forever, and every subsequent call in that session hits the same failure.

Production symptom: continuous `receipt creation failed: UNIQUE constraint failed` errors for ~1 minute until the session ends, with all receipts lost for that window.

## Fix

Add `recoverChainState()` in `src/hooks.ts`, called in `afterToolCall` whenever the in-memory state looks fresh (`sequence===0 && previousReceiptHash===null`). It calls `store.getChain(chainId)`, and if prior receipts exist, restores `state.sequence` and `state.previousReceiptHash` from the last one — allowing the next receipt to continue the chain correctly. A `logger.warn` fires when recovery actually triggers, giving operators a breadcrumb in logs.

Recovery fires at most once per session per process lifetime (the guard condition cannot be true after even a single `advanceChain`).

## Changes

- **`src/hooks.ts`**: `recoverChainState()` helper + call site guard in `afterToolCall`
- **`src/hooks.test.ts`**: three new cases in `"chain recovery after plugin restart"`:
  - Full regression test: populates store, clears in-memory state, verifies the post-restart receipt lands at seq 3 with correct hash linkage, and `verifyChain` passes across the restart boundary
  - Idempotence: recovery does not re-trigger on subsequent calls
  - No-op path: empty store → chain starts at seq 1 as normal

## Notes for reviewer

- `store.getChain()` and all other operations between `getChainState` and `advanceChain` are synchronous — no JS concurrency hazard introduced
- Recovery uses `hashReceipt(last)` rather than any stored hash field, keeping the cryptographic linkage sound
- The `sequence===0 && previousReceiptHash===null` trigger is indistinguishable from a genuine new session with a reused `(sessionKey, sessionId)`. This is safe as long as session IDs are unique (UUIDs in practice), but noted as a known assumption