### PR TITLE
chore: release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-27
+
+### Fixed
+- Recover chain state from the store after a plugin restart. When the process restarts
+  mid-session, the in-memory sequence counter was re-initialised to 0 while the database
+  still held prior receipts, causing every subsequent `store.insert` to fail with
+  `UNIQUE constraint failed: receipts.chain_id, receipts.sequence` and leaving the chain
+  permanently stuck for that session (#103).
+
 ## [0.4.0] - 2026-04-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Bumps version to `0.4.1` and updates the changelog.

## Changes since 0.4.0

- **fix: recover chain state from store after plugin restart** (#103) — fixes continuous `UNIQUE constraint failed: receipts.chain_id, receipts.sequence` errors when the plugin restarts mid-session.

## Release checklist

- [ ] PR merged to main
- [ ] GitHub release `v0.4.1` created → triggers `publish.yml` → publishes to npm