### PR TITLE
fix: scope session_start pending eviction to current session only

### DIFF
--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -234,21 +234,6 @@ describe("hooks", () => {
       expect(result.valid).toBe(true);
       expect(result.length).toBe(3);
     });
-
-    it("hashReceipt is stable across a JSON round-trip through the store", async () => {
-      await simulateToolCall(deps, "read_file", { path: "/a.txt" });
-
-      const chainId = "chain_openclaw_test-session_sid-1";
-      // Retrieve the receipt that was stored (goes through JSON.stringify → SQLite → JSON.parse)
-      const retrieved = store.getChain(chainId)[0]!;
-      // Compute hash from retrieved receipt and compare to what recoverChainState would compute
-      const roundTripHash = hashReceipt(retrieved);
-      // The next receipt must link to this hash — confirm it matches what advanceChain stored
-      deps.chains.clear();
-      await simulateToolCall(deps, "write_file", { path: "/b.txt" }, { toolCallId: "tc-2" });
-      const chain = store.getChain(chainId);
-      expect(chain[1]!.credentialSubject.chain.previous_receipt_hash).toBe(roundTripHash);
-    });
   });
 
   describe("pending stash", () => {
@@ -276,6 +261,38 @@ describe("hooks", () => {
 
       // Receipt was created even without stashed data
       expect(store.stats().total).toBe(1);
+    });
+
+    it("tags each pending entry with its session so cross-session eviction is possible", () => {
+      beforeToolCall(
+        { toolName: "read_file", params: { path: "/a.txt" }, runId: "rA", toolCallId: "tcA" },
+        { sessionKey: "session-A" },
+        deps,
+      );
+      beforeToolCall(
+        { toolName: "read_file", params: { path: "/b.txt" }, runId: "rB", toolCallId: "tcB" },
+        { sessionKey: "session-B" },
+        deps,
+      );
+
+      // Mirror the index.ts session_start eviction: only entries for the
+      // starting session should be removed.
+      const startingSession = "session-B";
+      for (const [key, entry] of deps.pending) {
+        if (entry.sessionKey === startingSession) deps.pending.delete(key);
+      }
+
+      expect(deps.pending.has("rA:tcA")).toBe(true);
+      expect(deps.pending.has("rB:tcB")).toBe(false);
+    });
+
+    it("falls back to 'default' sessionKey when ctx.sessionKey is absent", () => {
+      beforeToolCall(
+        { toolName: "read_file", params: { path: "/a.txt" }, runId: "r1", toolCallId: "tc1" },
+        {},
+        deps,
+      );
+      expect(deps.pending.get("r1:tc1")?.sessionKey).toBe("default");
     });
   });
 });

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -8,7 +8,13 @@ import {
   sha256,
   type ReceiptStore,
 } from "@agnt-rcpt/sdk-ts";
-import { beforeToolCall, afterToolCall, shouldPreview, extractPreview } from "./hooks.js";
+import {
+  beforeToolCall,
+  afterToolCall,
+  evictPendingForSession,
+  shouldPreview,
+  extractPreview,
+} from "./hooks.js";
 import { makeHookDeps, simulateToolCall } from "./test-helpers.js";
 
 describe("hooks", () => {
@@ -263,27 +269,61 @@ describe("hooks", () => {
       expect(store.stats().total).toBe(1);
     });
 
-    it("tags each pending entry with its session so cross-session eviction is possible", () => {
+    it("evictPendingForSession only removes entries for the matching session", () => {
       beforeToolCall(
         { toolName: "read_file", params: { path: "/a.txt" }, runId: "rA", toolCallId: "tcA" },
-        { sessionKey: "session-A" },
+        { sessionKey: "session-A", sessionId: "sid-A" },
         deps,
       );
       beforeToolCall(
         { toolName: "read_file", params: { path: "/b.txt" }, runId: "rB", toolCallId: "tcB" },
-        { sessionKey: "session-B" },
+        { sessionKey: "session-B", sessionId: "sid-B" },
         deps,
       );
 
-      // Mirror the index.ts session_start eviction: only entries for the
-      // starting session should be removed.
-      const startingSession = "session-B";
-      for (const [key, entry] of deps.pending) {
-        if (entry.sessionKey === startingSession) deps.pending.delete(key);
-      }
+      evictPendingForSession(deps.pending, "session-B", "sid-B");
 
       expect(deps.pending.has("rA:tcA")).toBe(true);
       expect(deps.pending.has("rB:tcB")).toBe(false);
+    });
+
+    it("evictPendingForSession distinguishes sessions sharing a sessionKey by sessionId", () => {
+      // Two sessions under the same sessionKey but different sessionIds —
+      // the chain state in chain.ts is keyed by (sessionKey, sessionId), so
+      // pending eviction must match both fields, not just sessionKey.
+      beforeToolCall(
+        { toolName: "read_file", params: { path: "/a.txt" }, runId: "r1", toolCallId: "tc1" },
+        { sessionKey: "default", sessionId: "sid-A" },
+        deps,
+      );
+      beforeToolCall(
+        { toolName: "read_file", params: { path: "/b.txt" }, runId: "r2", toolCallId: "tc2" },
+        { sessionKey: "default", sessionId: "sid-B" },
+        deps,
+      );
+
+      evictPendingForSession(deps.pending, "default", "sid-B");
+
+      expect(deps.pending.has("r1:tc1")).toBe(true);
+      expect(deps.pending.has("r2:tc2")).toBe(false);
+    });
+
+    it("evictPendingForSession matches undefined sessionId only to undefined", () => {
+      beforeToolCall(
+        { toolName: "read_file", params: { path: "/a.txt" }, runId: "r1", toolCallId: "tc1" },
+        { sessionKey: "default" },
+        deps,
+      );
+      beforeToolCall(
+        { toolName: "read_file", params: { path: "/b.txt" }, runId: "r2", toolCallId: "tc2" },
+        { sessionKey: "default", sessionId: "sid-B" },
+        deps,
+      );
+
+      evictPendingForSession(deps.pending, "default", undefined);
+
+      expect(deps.pending.has("r1:tc1")).toBe(false);
+      expect(deps.pending.has("r2:tc2")).toBe(true);
     });
 
     it("falls back to 'default' sessionKey when ctx.sessionKey is absent", () => {

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   openStore,
   verifyChain,
+  verifyStoredChain,
   hashReceipt,
   canonicalize,
   sha256,
@@ -218,6 +219,35 @@ describe("hooks", () => {
       expect(chain).toHaveLength(1);
       expect(chain[0]!.credentialSubject.chain.sequence).toBe(1);
       expect(chain[0]!.credentialSubject.chain.previous_receipt_hash).toBeNull();
+    });
+
+    it("verifyStoredChain passes after recovery (exercises the production code path)", async () => {
+      await simulateToolCall(deps, "read_file", { path: "/a.txt" }, { toolCallId: "tc-1" });
+      await simulateToolCall(deps, "write_file", { path: "/b.txt" }, { toolCallId: "tc-2" });
+
+      deps.chains.clear();
+
+      await simulateToolCall(deps, "delete_file", { path: "/c.txt" }, { toolCallId: "tc-3" });
+
+      const chainId = "chain_openclaw_test-session_sid-1";
+      const result = verifyStoredChain(store, chainId, deps.publicKey);
+      expect(result.valid).toBe(true);
+      expect(result.length).toBe(3);
+    });
+
+    it("hashReceipt is stable across a JSON round-trip through the store", async () => {
+      await simulateToolCall(deps, "read_file", { path: "/a.txt" });
+
+      const chainId = "chain_openclaw_test-session_sid-1";
+      // Retrieve the receipt that was stored (goes through JSON.stringify → SQLite → JSON.parse)
+      const retrieved = store.getChain(chainId)[0]!;
+      // Compute hash from retrieved receipt and compare to what recoverChainState would compute
+      const roundTripHash = hashReceipt(retrieved);
+      // The next receipt must link to this hash — confirm it matches what advanceChain stored
+      deps.chains.clear();
+      await simulateToolCall(deps, "write_file", { path: "/b.txt" }, { toolCallId: "tc-2" });
+      const chain = store.getChain(chainId);
+      expect(chain[1]!.credentialSubject.chain.previous_receipt_hash).toBe(roundTripHash);
     });
   });
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -28,6 +28,7 @@ export type PendingCall = {
   startedAt: string;
   paramsHash: string;
   sessionKey: string;
+  sessionId?: string;
 };
 
 export type PendingMap = Map<string, PendingCall>;
@@ -142,7 +143,25 @@ export function beforeToolCall(
     startedAt: new Date().toISOString(),
     paramsHash: sha256(canonicalize(event.params)),
     sessionKey: ctx.sessionKey ?? "default",
+    sessionId: ctx.sessionId,
   });
+}
+
+/**
+ * Evict pending entries whose stash belongs to the given session.
+ * Matches on both sessionKey and sessionId so two sessions sharing a
+ * sessionKey but with different sessionIds do not trample each other.
+ */
+export function evictPendingForSession(
+  pending: PendingMap,
+  sessionKey: string,
+  sessionId: string | undefined,
+): void {
+  for (const [key, entry] of pending) {
+    if (entry.sessionKey === sessionKey && entry.sessionId === sessionId) {
+      pending.delete(key);
+    }
+  }
 }
 
 /**

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -27,6 +27,7 @@ export type PendingCall = {
   params: Record<string, unknown>;
   startedAt: string;
   paramsHash: string;
+  sessionKey: string;
 };
 
 export type PendingMap = Map<string, PendingCall>;
@@ -129,7 +130,7 @@ function evictStalePending(pending: PendingMap): void {
  */
 export function beforeToolCall(
   event: { toolName: string; params: Record<string, unknown>; runId?: string; toolCallId?: string },
-  _ctx: { sessionKey?: string; sessionId?: string },
+  ctx: { sessionKey?: string; sessionId?: string },
   deps: HookDeps,
 ): void {
   evictStalePending(deps.pending);
@@ -140,6 +141,7 @@ export function beforeToolCall(
     params: event.params,
     startedAt: new Date().toISOString(),
     paramsHash: sha256(canonicalize(event.params)),
+    sessionKey: ctx.sessionKey ?? "default",
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,13 @@ import { openStore } from "@agnt-rcpt/sdk-ts";
 
 import { resolveConfig, loadOrCreateKeys } from "./config.js";
 import { loadCustomMappings, DEFAULT_MAPPINGS, DEFAULT_PATTERNS } from "./classify.js";
-import { beforeToolCall, afterToolCall, type HookDeps, type PendingMap } from "./hooks.js";
+import {
+  beforeToolCall,
+  afterToolCall,
+  evictPendingForSession,
+  type HookDeps,
+  type PendingMap,
+} from "./hooks.js";
 import { resetChain, getChainId, type ChainsMap, type ChainState } from "./chain.js";
 import { createQueryReceiptsToolFactory, createVerifyChainToolFactory } from "./tools.js";
 
@@ -74,9 +80,7 @@ export default definePluginEntry({
       const sessionKey = ctx.sessionKey ?? "default";
       const sessionId = ctx.sessionId;
       resetChain(chains, sessionKey, sessionId);
-      for (const [key, entry] of pending) {
-        if (entry.sessionKey === sessionKey) pending.delete(key);
-      }
+      evictPendingForSession(pending, sessionKey, sessionId);
       api.logger.info(`agent-receipts: new chain for session ${sessionKey}`);
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,9 @@ export default definePluginEntry({
       const sessionKey = ctx.sessionKey ?? "default";
       const sessionId = ctx.sessionId;
       resetChain(chains, sessionKey, sessionId);
-      pending.clear();
+      for (const [key, entry] of pending) {
+        if (entry.sessionKey === sessionKey) pending.delete(key);
+      }
       api.logger.info(`agent-receipts: new chain for session ${sessionKey}`);
     });
 


### PR DESCRIPTION
## What changed

- `session_start` in [src/index.ts](src/index.ts) called `pending.clear()`, evicting every in-flight `before_tool_call` stash regardless of which session it belonged to.
- `PendingCall` now carries a `sessionKey` (set in `beforeToolCall` from the previously-ignored `ctx`), and the `session_start` handler iterates and removes only entries for the starting session.
- Three new tests:
  - `verifyStoredChain passes after recovery` — exercises the production verification API on a recovered chain (the existing tests use `verifyChain(array, ...)`)
  - `tags each pending entry with its session so cross-session eviction is possible` — pins down the contract this PR introduces
  - `falls back to "default" sessionKey when ctx.sessionKey is absent` — covers the optional-ctx fallback

## Concrete consequence of the bug

When `pending.clear()` wiped a stash that another session needed, `afterToolCall` for that session would find no stashed entry and fall through to:
- `paramsHash = sha256(canonicalize(event.params))` — recomputed, same value (harmless)
- `actionTimestamp: stashed?.startedAt` → `undefined` → `createReceipt` falls back to `now` — the receipt records the *post-execution* time as the action start time, not the captured `before_tool_call` time

That's a data-quality regression in the audit trail (timing skew on the order of however long the tool took to run). It doesn't break the hash chain — every receipt's hash is computed over its actual content, and links between receipts stay consistent.

## What this PR does *not* fix

The "tampering at position 1" symptom from the user's interactive demo. I never reproduced that locally and I don't have the SQLite file. The most plausible explanation is pre-existing inconsistent data in the on-disk store (e.g., old receipts signed under a key that was later regenerated), but I cannot prove that from this repo. If the symptom recurs on a fresh DB with a stable key, there's a different bug somewhere that this PR will not catch.

## Why this is *not* a race-condition fix

`afterToolCall` is declared `async` but contains zero `await` points — every operation it calls (`signReceipt`, `hashReceipt`, `store.insert`, `advanceChain`) is synchronous. In Node.js's single-threaded event loop, an async function with no awaits runs to completion in one tick; concurrent invocations cannot interleave inside it. A mutex would be a no-op.

## Test plan

- [x] `pnpm test` — 152 pass (149 pre-existing + 3 new)
- [x] `pnpm typecheck` — clean