### PR TITLE
fix: classify sessions_spawn and subagents as high risk (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Classify `sessions_spawn` and `subagents` as `system.command.execute` (high risk)
+  instead of `system.application.launch` (low risk). Spawning a new agent session is
+  a high-privilege operation; receipts now reflect that in audit trails (#106).
+
 ## [0.4.1] - 2026-04-27
 
 ### Fixed

--- a/src/classify.test.ts
+++ b/src/classify.test.ts
@@ -91,10 +91,16 @@ describe("classify", () => {
     expect(result.risk_level).toBe("low");
   });
 
-  it("maps sessions_spawn to system.application.launch with low risk", () => {
+  it("maps sessions_spawn to system.command.execute with high risk", () => {
     const result = classify("sessions_spawn", DEFAULT_MAPPINGS);
-    expect(result.action_type).toBe("system.application.launch");
-    expect(result.risk_level).toBe("low");
+    expect(result.action_type).toBe("system.command.execute");
+    expect(result.risk_level).toBe("high");
+  });
+
+  it("maps subagents to system.command.execute with high risk", () => {
+    const result = classify("subagents", DEFAULT_MAPPINGS);
+    expect(result.action_type).toBe("system.command.execute");
+    expect(result.risk_level).toBe("high");
   });
 
   it("maps process to system.command.execute with high risk", () => {

--- a/taxonomy.json
+++ b/taxonomy.json
@@ -41,9 +41,9 @@
     { "tool_name": "sessions_history",  "action_type": "filesystem.file.read" },
     { "tool_name": "session_status",    "action_type": "filesystem.file.read" },
     { "tool_name": "sessions_send",     "action_type": "system.application.control" },
-    { "tool_name": "sessions_spawn",    "action_type": "system.application.launch" },
+    { "tool_name": "sessions_spawn",    "action_type": "system.command.execute" },
     { "tool_name": "sessions_yield",    "action_type": "system.application.control" },
-    { "tool_name": "subagents",         "action_type": "system.application.launch" },
+    { "tool_name": "subagents",         "action_type": "system.command.execute" },
     { "tool_name": "agents_list",       "action_type": "filesystem.file.read" },
 
     { "tool_name": "browser",           "action_type": "system.browser.navigate" },


### PR DESCRIPTION
## Summary
- Remap `sessions_spawn` and `subagents` in `taxonomy.json` from `system.application.launch` (low risk) to `system.command.execute` (high risk).
- Update `src/classify.test.ts` — adjust the existing `sessions_spawn` test, add a parallel `subagents` test (previously uncovered).
- CHANGELOG entry under `[Unreleased]`.

Closes #106.

## Why this mapping

The SDK ships a fixed action-type list and does not currently expose a `system.application.spawn` type. The issue's option 2 — remap to the existing high-risk `system.command.execute` — is the pragmatic fix. Spawning an agent isn't literally a shell command, but it produces side-effects on behalf of the user with at least equivalent privilege, so the risk classification matches even if the description is imperfect. A future SDK release that adds a dedicated `system.application.spawn` type would be the long-term clean fix.

## Notes / follow-ups (out of scope)

- The `sessions_` prefix pattern in `taxonomy.json` still maps to `system.application.control` (medium). Any future `sessions_*` agent-spawning tool that lacks an exact mapping would silently fall back to medium. Worth tightening separately if more spawn-like tools land.
- `sessions_send` (medium) sends data into another agent's context and arguably has similar privilege concerns — also a separate discussion.

## Test plan
- [x] `pnpm test` — all 150 tests pass, including the new/updated `classify` cases.
- [x] `pnpm typecheck` — clean.