### PR TITLE
docs: document parameterPreview, fix profile:full example, update ecosystem link

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,10 +256,13 @@ Options:
 
 With `"high"` enabled, a `system.command.execute` receipt includes:
 
-```json
-"parameters_hash": "sha256:9c84a8c9...",
-"parameters_preview": {
-  "command": "echo \"Testing agent-receipts plugin fix\""
+```jsonc
+{
+  // ...other receipt fields
+  "parameters_hash": "sha256:9c84a8c9...",
+  "parameters_preview": {
+    "command": "echo \"Testing agent-receipts plugin fix\""
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ pnpm test:coverage     # with V8 coverage
 | [agent-receipts/sdk-ts](https://github.com/agent-receipts/ar/tree/main/sdk/ts) | TypeScript SDK |
 | [agent-receipts/sdk-py](https://github.com/agent-receipts/ar/tree/main/sdk/py) | Python SDK ([PyPI](https://pypi.org/project/agent-receipts/)) |
 | **agent-receipts/openclaw** (this plugin) | OpenClaw integration |
-| [ojongerius/attest](https://github.com/ojongerius/attest) | MCP proxy + CLI (reference implementation) |
+| [agent-receipts/ar/mcp-proxy](https://github.com/agent-receipts/ar/tree/main/mcp-proxy) | MCP proxy + CLI |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Verifying the chain confirms nothing was tampered with:
 Chain "chain_openclaw_main_sid-42" is valid: 5 receipts, all signatures and hash links verified.
 ```
 
-Every receipt is a signed [W3C Verifiable Credential](https://www.w3.org/TR/vc-data-model-2.0/) — parameters are hashed (never stored in plaintext), and each receipt is hash-linked to the previous one, forming a tamper-evident chain.
+Every receipt is a signed [W3C Verifiable Credential](https://www.w3.org/TR/vc-data-model-2.0/) — parameters are hashed by default (with optional plaintext preview via `parameterPreview`), and each receipt is hash-linked to the previous one, forming a tamper-evident chain.
 
 ---
 
@@ -173,7 +173,7 @@ Each receipt is a W3C Verifiable Credential signed with Ed25519, recording:
 | **Action** | What happened — classified type, risk level, target tool |
 | **Outcome** | Success/failure status and error details |
 | **Chain** | Sequence number + SHA-256 hash link to previous receipt |
-| **Privacy** | Parameters are hashed, never stored in plaintext |
+| **Privacy** | Parameters are hashed by default; opt in via `parameterPreview` to include selected fields in plaintext |
 | **Proof** | Ed25519Signature2020 with verification method |
 
 ## Taxonomy
@@ -216,7 +216,7 @@ Default config block:
           "enabled": true,
           "dbPath": "~/.openclaw/agent-receipts/receipts.db",
           "keyPath": "~/.openclaw/agent-receipts/keys.json",
-          "taxonomyPath": null,
+          // "taxonomyPath": "/path/to/custom-taxonomy.json",  // optional — overrides bundled taxonomy
           "parameterPreview": false  // false | true | "high" | string[]
         }
       }
@@ -247,7 +247,7 @@ By default, action parameters are hashed but not stored in plaintext. Enable `pa
 
 Options:
 
-| Value | Behaviour |
+| Value | Behavior |
 |:---|:---|
 | `false` | Hashes only — no plaintext (default) |
 | `true` | Preview enabled for all action types |
@@ -266,7 +266,7 @@ With `"high"` enabled, a `system.command.execute` receipt includes:
 }
 ```
 
-The hash always covers the full original parameters regardless of preview config. The preview is additive and opt-in — fields disclosed are defined per action type in the taxonomy.
+The hash always covers the full original parameters regardless of preview config. Only the **first** matching field from the taxonomy's `preview_fields` list is included in `parameters_preview`, and non-string values are JSON-stringified. Previewed values are stored verbatim — do not list fields that may contain secrets.
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,67 @@ All settings are optional — the plugin works out of the box with sensible defa
 | `dbPath` | `~/.openclaw/agent-receipts/receipts.db` | SQLite receipt database path |
 | `keyPath` | `~/.openclaw/agent-receipts/keys.json` | Ed25519 signing key pair path |
 | `taxonomyPath` | _(bundled)_ | Custom tool-to-action-type mapping |
+| `parameterPreview` | `false` | Selectively disclose parameters in plaintext (see below) |
+
+Default config block:
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openclaw-agent-receipts": {
+        "config": {
+          "enabled": true,
+          "dbPath": "~/.openclaw/agent-receipts/receipts.db",
+          "keyPath": "~/.openclaw/agent-receipts/keys.json",
+          "taxonomyPath": null,
+          "parameterPreview": false  // false | true | "high" | string[]
+        }
+      }
+    }
+  }
+}
+```
 
 Ed25519 signing keys are generated automatically on first run and persisted to `keyPath`.
+
+### Parameter preview
+
+By default, action parameters are hashed but not stored in plaintext. Enable `parameterPreview` to selectively disclose specific fields per action type — useful for auditing high-risk commands without exposing sensitive data on lower-risk calls.
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openclaw-agent-receipts": {
+        "config": {
+          "parameterPreview": "high"
+        }
+      }
+    }
+  }
+}
+```
+
+Options:
+
+| Value | Behaviour |
+|:---|:---|
+| `false` | Hashes only — no plaintext (default) |
+| `true` | Preview enabled for all action types |
+| `"high"` | Preview enabled for `high` and `critical` risk actions only |
+| `["system.command.execute"]` | Preview enabled for specific action types |
+
+With `"high"` enabled, a `system.command.execute` receipt includes:
+
+```json
+"parameters_hash": "sha256:9c84a8c9...",
+"parameters_preview": {
+  "command": "echo \"Testing agent-receipts plugin fix\""
+}
+```
+
+The hash always covers the full original parameters regardless of preview config. The preview is additive and opt-in — fields disclosed are defined per action type in the taxonomy.
 
 ## Project structure
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -62,7 +62,7 @@ All config is optional with sensible defaults:
           "enabled": true,
           "dbPath": "~/.openclaw/agent-receipts/receipts.db",
           "keyPath": "~/.openclaw/agent-receipts/keys.json",
-          "taxonomyPath": null,           // custom taxonomy mapping
+          // "taxonomyPath": "/path/to/custom-taxonomy.json",  // optional — overrides bundled taxonomy
           "parameterPreview": false       // false | true | "high" | string[]
         }
       }
@@ -91,8 +91,8 @@ By default, action parameters are hashed but not stored in plaintext. Enable `pa
 
 Options:
 
-| Value | Behaviour |
-|-------|-----------|
+| Value | Behavior |
+|-------|----------|
 | `false` | Hashes only — no plaintext (default) |
 | `true` | Preview enabled for all action types |
 | `"high"` | Preview enabled for `high` and `critical` risk actions only |
@@ -110,7 +110,7 @@ With `"high"` enabled, a `system.command.execute` receipt includes:
 }
 ```
 
-The hash always covers the full original parameters regardless of preview config. The preview is additive and opt-in — fields disclosed are defined per action type in the taxonomy.
+The hash always covers the full original parameters regardless of preview config. Only the **first** matching field from the taxonomy's `preview_fields` list is included in `parameters_preview`, and non-string values are JSON-stringified. Previewed values are stored verbatim — do not list fields that may contain secrets.
 
 ## Verifying
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -100,10 +100,13 @@ Options:
 
 With `"high"` enabled, a `system.command.execute` receipt includes:
 
-```json
-"parameters_hash": "sha256:9c84a8c9...",
-"parameters_preview": {
-  "command": "echo \"Testing agent-receipts plugin fix\""
+```jsonc
+{
+  // ...other receipt fields
+  "parameters_hash": "sha256:9c84a8c9...",
+  "parameters_preview": {
+    "command": "echo \"Testing agent-receipts plugin fix\""
+  }
 }
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -28,8 +28,17 @@ installing you must allowlist the two agent-receipts tools in your `openclaw.jso
 Without this, the plugin will still load (hooks fire, receipts are
 generated), but the agent will not see the query/verify tools.
 
-Alternatively, you can use `"profile": "full"` to allow all registered
-tools, or allowlist the entire plugin by ID:
+Alternatively, switch to the `"full"` profile to allow all registered tools:
+
+```jsonc
+{
+  "tools": {
+    "profile": "full"
+  }
+}
+```
+
+Or allowlist the entire plugin by ID:
 
 ```jsonc
 {
@@ -53,13 +62,52 @@ All config is optional with sensible defaults:
           "enabled": true,
           "dbPath": "~/.openclaw/agent-receipts/receipts.db",
           "keyPath": "~/.openclaw/agent-receipts/keys.json",
-          "taxonomyPath": null  // custom taxonomy mapping
+          "taxonomyPath": null,           // custom taxonomy mapping
+          "parameterPreview": false       // false | true | "high" | string[]
         }
       }
     }
   }
 }
 ```
+
+## Parameter preview
+
+By default, action parameters are hashed but not stored in plaintext. Enable `parameterPreview` to selectively disclose specific fields per action type — useful for auditing high-risk commands without exposing sensitive data on lower-risk calls.
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openclaw-agent-receipts": {
+        "config": {
+          "parameterPreview": "high"
+        }
+      }
+    }
+  }
+}
+```
+
+Options:
+
+| Value | Behaviour |
+|-------|-----------|
+| `false` | Hashes only — no plaintext (default) |
+| `true` | Preview enabled for all action types |
+| `"high"` | Preview enabled for `high` and `critical` risk actions only |
+| `["system.command.execute"]` | Preview enabled for specific action types |
+
+With `"high"` enabled, a `system.command.execute` receipt includes:
+
+```json
+"parameters_hash": "sha256:9c84a8c9...",
+"parameters_preview": {
+  "command": "echo \"Testing agent-receipts plugin fix\""
+}
+```
+
+The hash always covers the full original parameters regardless of preview config. The preview is additive and opt-in — fields disclosed are defined per action type in the taxonomy.
 
 ## Verifying
 


### PR DESCRIPTION
## Summary

Docs-only changes to align README and INSTALL with the current plugin behaviour. No release needed.

- **Document `parameterPreview`** in `README.md` and `docs/INSTALL.md`
  - Adds a row to the config table and a default config block in the README
  - Adds a *Parameter preview* section explaining values (`false` / `true` / `"high"` / `string[]`), semantics (`"high"` covers both `high` and `critical` risk), and what the preview looks like in a receipt
- **Fix the `profile: "full"` example in `docs/INSTALL.md`** — the previous wording named two alternatives (full profile vs. plugin-ID allowlisting) but only showed one code block. Split into two clear examples.
- **Replace deprecated `ojongerius/attest` link** in the Ecosystem table with [`agent-receipts/ar/mcp-proxy`](https://github.com/agent-receipts/ar/tree/main/mcp-proxy).

The corresponding site update lives in [agent-receipts/ar#247](https://github.com/agent-receipts/ar/pull/247).

## Test plan

- [ ] Read the rendered README on the PR — config table reads correctly; *Parameter preview* subsection renders with the table and code blocks intact
- [ ] Read `docs/INSTALL.md` on the PR — two separate code blocks for `profile: "full"` and plugin-ID allowlisting; *Parameter preview* section appears between *Configuration* and *Verifying*
- [ ] Click the new `agent-receipts/ar/mcp-proxy` link; verify it resolves