### PR TITLE
docs: improve CLI reference for subcommands, receipt querying, and parameterPreview

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,14 @@ Then enable the plugin in your OpenClaw config. See [`docs/INSTALL.md`](docs/INS
 
 Query and verify receipts outside of agent sessions, useful for auditing and debugging.
 
+| Subcommand | Description |
+|:-----------|:------------|
+| `receipts` | List and query receipts (returns a collection) |
+| `verify`   | Verify chain integrity (signatures + hash links) |
+| `export`   | Export receipts as JSON-LD W3C Verifiable Credentials |
+
 ```bash
-# Query all receipts
+# List all receipts
 npx @agnt-rcpt/openclaw receipts
 
 # Filter by risk level
@@ -115,6 +121,13 @@ npx @agnt-rcpt/openclaw receipts --risk high
 
 # Filter by action type and output as JSON
 npx @agnt-rcpt/openclaw receipts --action system.command.execute --json
+
+# `receipts` always returns a collection — use `export --id` to fetch a single receipt by ID
+npx @agnt-rcpt/openclaw export --id urn:receipt:abc-123
+
+# Filter JSON output with jq (find exec commands containing "rm")
+npx @agnt-rcpt/openclaw receipts --action system.command.execute --json \
+  | jq '.receipts[] | select(.parameters_preview.command | strings | contains("rm"))'
 
 # Verify all chains
 npx @agnt-rcpt/openclaw verify
@@ -127,10 +140,9 @@ npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42
 
 # Export as a W3C Verifiable Presentation envelope
 npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42 --format presentation
-
-# Export a single receipt by ID
-npx @agnt-rcpt/openclaw export --id urn:receipt:abc-123
 ```
+
+> **Note:** `parameters_preview` is empty by default. Set `"parameterPreview": "high"` (or `true`) in your plugin config to see plaintext parameter values for high-risk actions. See [Parameter preview](#parameter-preview) for details.
 
 Run `npx @agnt-rcpt/openclaw --help` for all options including `--status`, `--limit`, and `--db`.
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ npx @agnt-rcpt/openclaw receipts --action system.command.execute --json
 # `receipts` always returns a collection — use `export --id` to fetch a single receipt by ID
 npx @agnt-rcpt/openclaw export --id urn:receipt:abc-123
 
-# Filter JSON output with jq (find exec commands containing "rm")
-npx @agnt-rcpt/openclaw receipts --action system.command.execute --json \
-  | jq '.receipts[] | select(.parameters_preview.command | strings | contains("rm"))'
+# Filter receipts --json output with jq (fields: id, action, risk, target, status, sequence, chain_id, timestamp)
+npx @agnt-rcpt/openclaw receipts --json \
+  | jq '.receipts[] | select(.risk == "high" and .action == "system.command.execute")'
 
 # Verify all chains
 npx @agnt-rcpt/openclaw verify
@@ -142,7 +142,7 @@ npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42
 npx @agnt-rcpt/openclaw export --chain chain_openclaw_main_sid-42 --format presentation
 ```
 
-> **Note:** `parameters_preview` is empty by default. Set `"parameterPreview": "high"` (or `true`) in your plugin config to see plaintext parameter values for high-risk actions. See [Parameter preview](#parameter-preview) for details.
+> **Note:** `parameterPreview` controls what gets stored inside receipts — it does not add fields to `receipts --json` output. To inspect `parameters_preview` values, export the full receipt with `export --id` or `export --chain`. See [Parameter preview](#parameter-preview) for configuration details.
 
 Run `npx @agnt-rcpt/openclaw --help` for all options including `--status`, `--limit`, and `--db`.
 


### PR DESCRIPTION
## Summary

Addresses the three friction points raised in #112:

- **Subcommand discoverability** — added a `| Subcommand | Description |` table at the top of the CLI section so users can see `receipts`, `verify`, and `export` at a glance without reading through examples
- **`receipts` vs `export --id` confusion** — the `export --id` example is now positioned directly after the `receipts --json` example with an inline comment: `` `receipts` always returns a collection — use `export --id` to fetch a single receipt by ID ``; this surfaces the distinction where the confusion happens rather than burying it at the bottom of the code block
- **`parameters_preview` empty** — added a blockquote callout after the code block pointing users to the `parameterPreview` config option and the existing Parameter preview section, so they don't have to stumble across it

Also added a `jq` filtering example showing how to pipe `--json` output through `jq` to select by field value, which came up in the issue as a useful workflow.

No code changes — docs only.

Closes #112