### PR TITLE
docs: document correct gateway restart command and hot-reload behaviour

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -114,7 +114,21 @@ The hash always covers the full original parameters regardless of preview config
 
 ## Verifying
 
-After setup, restart the gateway and confirm the plugin loaded:
+**After `openclaw plugins install`** the gateway must be restarted before the plugin is active.
+`openclaw.json` changes (tool policy, plugin config) are hot-reloaded and do not require a restart.
+
+Restart the gateway with the appropriate command for your setup:
+
+```bash
+# systemd (most Linux installs)
+systemctl restart openclaw-gateway
+```
+
+For other setups, stop and re-start the gateway process however it was launched.
+
+> **Note:** There is no `openclaw restart` command.
+
+Confirm the plugin loaded:
 
 ```bash
 openclaw plugins list

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -124,7 +124,7 @@ Restart the gateway with the appropriate command for your setup:
 systemctl restart openclaw-gateway
 ```
 
-For other setups, stop and re-start the gateway process however it was launched.
+For other setups, stop and restart the gateway process however it was launched.
 
 > **Note:** There is no `openclaw restart` command.
 


### PR DESCRIPTION
Fixes #92.

## Summary

- Rewrites the **Verifying** section of `docs/INSTALL.md` to replace the vague "restart the gateway" instruction with accurate, actionable guidance.
- Documents that `openclaw plugins install` requires a gateway restart before the plugin is active.
- Documents that `openclaw.json` changes (tool policy, plugin config) are hot-reloaded and do not require a restart.
- Gives the correct restart command (`systemctl restart openclaw-gateway` for systemd installs) and a note for other setups.
- Explicitly calls out that there is no `openclaw restart` command, to avoid the dead end described in the issue.

## Test plan

- [ ] Read the updated section and verify it renders correctly as markdown.
- [ ] Confirm `systemctl restart openclaw-gateway` on a systemd install restarts the gateway as expected.