### PR TITLE
chore: add release automation script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,36 @@ AI agents (Claude Code, GitHub Copilot, etc.) are first-class contributors to th
 
 **Agent boundaries** — agents must follow the [Agent safety rules](AGENTS.md#agent-safety-rules). Key constraints: no `openclaw.plugin.json` changes without human approval, no CI/CD workflow changes without explicit human review, no real cryptographic keys.
 
+## Release Process
+
+Releases are cut by maintainers using `scripts/release.sh`. The script handles the full flow end-to-end.
+
+```bash
+# Preview all steps without making any changes
+bash scripts/release.sh --dry-run patch
+
+# Cut a patch / minor / major release
+bash scripts/release.sh patch   # e.g. 0.4.2 → 0.4.3
+bash scripts/release.sh minor   # e.g. 0.4.2 → 0.5.0
+bash scripts/release.sh major   # e.g. 0.4.2 → 1.0.0
+
+# Pin to an exact version
+bash scripts/release.sh 1.0.0
+```
+
+**Prerequisites:** `gh` (GitHub CLI, authenticated), `git`, `node`, `npm`.
+
+What the script does:
+
+1. Validates preconditions — clean working tree, on `main`, required tools available
+2. Computes the new version
+3. Promotes `## [Unreleased]` in `CHANGELOG.md` to the new versioned entry
+4. Bumps `package.json`
+5. Commits (`chore(release): vX.Y.Z`), tags, and pushes
+6. Creates the GitHub Release — this triggers `publish.yml`, which publishes to npm
+
+Before cutting a release, make sure `CHANGELOG.md` has a complete `[Unreleased]` section describing all changes since the last tag.
+
 ## Pre-submit checklist
 
 Before opening a PR, verify:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -69,17 +69,23 @@ gh auth status &>/dev/null || die "gh is not authenticated — run 'gh auth logi
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 [[ "$BRANCH" == "main" ]] || die "must be on main branch (currently on '$BRANCH')"
 
-git diff --quiet          || die "unstaged changes present — commit or stash first"
-git diff --cached --quiet || die "staged changes present — commit or stash first"
+[[ -z "$(git status --porcelain)" ]] \
+  || die "working tree is not clean — commit, stash, or remove untracked files first"
 
 run git pull --ff-only
+
+# Guard: ensure no unpushed commits will sneak into the release push
+if [[ "$DRY_RUN" == false ]]; then
+  AHEAD=$(git rev-list --count "origin/main..HEAD")
+  [[ "$AHEAD" -eq 0 ]] || die "local main is ${AHEAD} commit(s) ahead of origin/main — push first"
+fi
 
 # ── Compute new version ───────────────────────────────────────────────────────
 
 CURRENT_VERSION=$(node -p "require('./package.json').version")
 
 [[ "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-  || die "package.json version '$CURRENT_VERSION' is not a clean X.Y.Z semver (prerelease versions are not supported)"
+  || die "package.json version '${CURRENT_VERSION}' is not a clean X.Y.Z — prerelease versions are not supported"
 
 IFS='.' read -r VER_MAJOR VER_MINOR VER_PATCH <<< "$CURRENT_VERSION"
 
@@ -95,10 +101,18 @@ case "$BUMP" in
     ;;
   *)
     [[ "$BUMP" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-      || die "invalid argument '$BUMP' — must be patch/minor/major or X.Y.Z"
+      || die "invalid argument '${BUMP}' — must be patch/minor/major or X.Y.Z"
     NEW_VERSION="$BUMP"
     ;;
 esac
+
+# Guard: new version must be strictly greater than current
+IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<< "$NEW_VERSION"
+if (( NEW_MAJOR < VER_MAJOR ||
+      ( NEW_MAJOR == VER_MAJOR && NEW_MINOR < VER_MINOR ) ||
+      ( NEW_MAJOR == VER_MAJOR && NEW_MINOR == VER_MINOR && NEW_PATCH <= VER_PATCH ) )); then
+  die "version '${NEW_VERSION}' must be strictly greater than current '${CURRENT_VERSION}'"
+fi
 
 TAG="v${NEW_VERSION}"
 RELEASE_DATE=$(date -u +%Y-%m-%d)
@@ -109,20 +123,22 @@ echo "    new: ${NEW_VERSION}  (${TAG})"
 echo
 
 if git rev-parse "$TAG" &>/dev/null; then
-  die "tag '$TAG' already exists"
+  die "tag '${TAG}' already exists"
 fi
 
 # ── Update CHANGELOG.md ───────────────────────────────────────────────────────
 
 if [[ "$DRY_RUN" == true ]]; then
-  echo "[dry-run] CHANGELOG.md: '## [Unreleased]' → '## [${NEW_VERSION}] - ${RELEASE_DATE}'"
+  echo "[dry-run] CHANGELOG.md: add '## [${NEW_VERSION}] - ${RELEASE_DATE}' and update reference links"
 else
   export NEW_VERSION RELEASE_DATE
   node << 'JSEOF'
 const fs = require('fs');
 const src = fs.readFileSync('CHANGELOG.md', 'utf8');
 const { NEW_VERSION, RELEASE_DATE } = process.env;
-const out = src.replace(
+
+// Promote [Unreleased] heading to a versioned entry; fresh empty [Unreleased] inserted above
+let out = src.replace(
   /^## \[Unreleased\]/m,
   `## [Unreleased]\n\n## [${NEW_VERSION}] - ${RELEASE_DATE}`,
 );
@@ -130,6 +146,17 @@ if (out === src) {
   process.stderr.write('error: CHANGELOG.md has no "## [Unreleased]" section\n');
   process.exit(1);
 }
+
+// Update Keep-a-Changelog reference links at the bottom
+const linkMatch = out.match(/^\[Unreleased\]:\s*(\S+?)\/compare\/v(\d+\.\d+\.\d+)\.\.\.HEAD\s*$/m);
+if (linkMatch) {
+  const [fullMatch, repoUrl, prevVersion] = linkMatch;
+  out = out.replace(
+    fullMatch,
+    `[Unreleased]: ${repoUrl}/compare/v${NEW_VERSION}...HEAD\n[${NEW_VERSION}]: ${repoUrl}/compare/v${prevVersion}...v${NEW_VERSION}`,
+  );
+}
+
 fs.writeFileSync('CHANGELOG.md', out);
 JSEOF
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# scripts/release.sh — Automate the openclaw release flow
+#
+# Usage:
+#   scripts/release.sh [--dry-run] <patch|minor|major|X.Y.Z>
+#
+# Steps:
+#   1. Validate preconditions (clean tree, on main, required tools present)
+#   2. Compute new version
+#   3. Promote CHANGELOG.md [Unreleased] to a versioned entry
+#   4. Bump package.json
+#   5. Commit, tag, and push
+#   6. Create GitHub Release — triggers publish.yml → npm publish
+set -euo pipefail
+
+cd "$(dirname "$0")/.." || { echo "error: cannot change to repo root" >&2; exit 1; }
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+
+usage() {
+  echo "Usage: $(basename "$0") [--dry-run] <patch|minor|major|X.Y.Z>" >&2
+  echo >&2
+  echo "  patch|minor|major  Bump the current version by that increment" >&2
+  echo "  X.Y.Z              Use this exact version" >&2
+  echo "  --dry-run          Print every step; make no changes" >&2
+  exit 1
+}
+
+# ── Arguments ─────────────────────────────────────────────────────────────────
+
+DRY_RUN=false
+BUMP=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    -*)        usage ;;
+    *)
+      [[ -n "$BUMP" ]] && usage
+      BUMP="$arg"
+      ;;
+  esac
+done
+
+[[ -z "$BUMP" ]] && usage
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# run <cmd> [args...] — execute normally, or just print in dry-run mode
+run() {
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "[dry-run]" "$@"
+  else
+    "$@"
+  fi
+}
+
+# ── Preconditions ─────────────────────────────────────────────────────────────
+
+for tool in gh git node npm; do
+  command -v "$tool" &>/dev/null || die "'$tool' not found in PATH"
+done
+
+gh auth status &>/dev/null || die "gh is not authenticated — run 'gh auth login' first"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[[ "$BRANCH" == "main" ]] || die "must be on main branch (currently on '$BRANCH')"
+
+git diff --quiet          || die "unstaged changes present — commit or stash first"
+git diff --cached --quiet || die "staged changes present — commit or stash first"
+
+run git pull --ff-only
+
+# ── Compute new version ───────────────────────────────────────────────────────
+
+CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+[[ "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+  || die "package.json version '$CURRENT_VERSION' is not a clean X.Y.Z semver (prerelease versions are not supported)"
+
+IFS='.' read -r VER_MAJOR VER_MINOR VER_PATCH <<< "$CURRENT_VERSION"
+
+case "$BUMP" in
+  patch)
+    NEW_VERSION="${VER_MAJOR}.${VER_MINOR}.$((VER_PATCH + 1))"
+    ;;
+  minor)
+    NEW_VERSION="${VER_MAJOR}.$((VER_MINOR + 1)).0"
+    ;;
+  major)
+    NEW_VERSION="$((VER_MAJOR + 1)).0.0"
+    ;;
+  *)
+    [[ "$BUMP" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+      || die "invalid argument '$BUMP' — must be patch/minor/major or X.Y.Z"
+    NEW_VERSION="$BUMP"
+    ;;
+esac
+
+TAG="v${NEW_VERSION}"
+RELEASE_DATE=$(date -u +%Y-%m-%d)
+
+echo "current: ${CURRENT_VERSION}"
+echo "    new: ${NEW_VERSION}  (${TAG})"
+[[ "$DRY_RUN" == true ]] && echo "(dry-run — no changes will be made)"
+echo
+
+if git rev-parse "$TAG" &>/dev/null; then
+  die "tag '$TAG' already exists"
+fi
+
+# ── Update CHANGELOG.md ───────────────────────────────────────────────────────
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "[dry-run] CHANGELOG.md: '## [Unreleased]' → '## [${NEW_VERSION}] - ${RELEASE_DATE}'"
+else
+  export NEW_VERSION RELEASE_DATE
+  node << 'JSEOF'
+const fs = require('fs');
+const src = fs.readFileSync('CHANGELOG.md', 'utf8');
+const { NEW_VERSION, RELEASE_DATE } = process.env;
+const out = src.replace(
+  /^## \[Unreleased\]/m,
+  `## [Unreleased]\n\n## [${NEW_VERSION}] - ${RELEASE_DATE}`,
+);
+if (out === src) {
+  process.stderr.write('error: CHANGELOG.md has no "## [Unreleased]" section\n');
+  process.exit(1);
+}
+fs.writeFileSync('CHANGELOG.md', out);
+JSEOF
+fi
+
+# ── Bump package.json ─────────────────────────────────────────────────────────
+
+run npm version "$NEW_VERSION" --no-git-tag-version
+
+# ── Commit, tag, push ─────────────────────────────────────────────────────────
+
+run git add CHANGELOG.md package.json
+run git commit -m "chore(release): ${TAG}"
+run git tag "$TAG"
+run git push origin main "$TAG"
+
+# ── Create GitHub Release ─────────────────────────────────────────────────────
+
+# If this step fails, the tag is already pushed. Retry with:
+#   gh release create "$TAG" --title "$TAG" --generate-notes
+run gh release create "$TAG" \
+  --title "$TAG" \
+  --generate-notes
+
+echo
+echo "Done. ${TAG} is live — publish.yml will handle npm publishing."


### PR DESCRIPTION
## Summary

- Adds `scripts/release.sh` to automate the full release flow end-to-end, eliminating the manual GitHub Release UI step that blocked `publish.yml`
- Validates preconditions (clean tree, on `main`, `gh` authenticated), bumps `package.json`, promotes `CHANGELOG.md [Unreleased]` to a versioned entry, commits, tags, pushes, and creates the GitHub Release
- Supports `patch`/`minor`/`major` increments and explicit `X.Y.Z` pins; includes `--dry-run` mode for safe rehearsal
- Documents the release process in `CONTRIBUTING.md`

## Usage

```bash
# Dry run — preview all steps, no changes
bash scripts/release.sh --dry-run patch

# Cut a release
bash scripts/release.sh patch   # 0.4.2 → 0.4.3
bash scripts/release.sh minor   # 0.4.2 → 0.5.0
bash scripts/release.sh major   # 0.4.2 → 1.0.0
bash scripts/release.sh 1.0.0   # exact pin
```

## Test plan

- [ ] `shellcheck scripts/release.sh` passes (verified locally)
- [ ] `pnpm test && pnpm typecheck` passes (verified locally)
- [ ] `bash scripts/release.sh --dry-run patch` prints expected steps without modifying any files
- [ ] CI shellcheck step picks up the new script

Closes #89.