### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-01
+
 ### Changed (breaking)
 - **Renamed `parameterPreview` → `parameterDisclosure`** (config option),
   `preview_fields` → `disclosure_fields` (taxonomy entries), and the receipt
@@ -119,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security hardening: key file permissions, input validation, pending-map memory
   leak prevention (#22).
 
-[Unreleased]: https://github.com/agent-receipts/openclaw/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/agent-receipts/openclaw/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/agent-receipts/openclaw/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/agent-receipts/openclaw/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/agent-receipts/openclaw/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/agent-receipts/openclaw/compare/v0.3.1...v0.3.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release commit for **v0.5.0** — promotes the `[Unreleased]` CHANGELOG section to a versioned entry and bumps `package.json` to `0.5.0`.

This corresponds to the rename to disclosure terminology that landed in [#116](https://github.com/agent-receipts/openclaw/pull/116) (`@agnt-rcpt/sdk-ts` 0.6.0 / ADR-0012).

## Why this is a separate PR

`scripts/release.sh` tried `git push origin main v0.5.0` which the branch protection on `main` rejected (PRs required). The tag `v0.5.0` was already accepted on the remote and points at the commit on this branch, so we need to land this exact SHA on `main`.

## Merge strategy

**Use "Create a merge commit"** — preserves the commit SHA so tag `v0.5.0` stays reachable from `main`'s history. Rebase or squash would change the SHA and orphan the tag.

## After merge

I'll run `gh release create v0.5.0 --generate-notes` to fire `publish.yml` → npm.

## Follow-up

`scripts/release.sh` needs a PR-based flow under branch protection — separate change.

## Test plan

- [x] CI green on the SDK-rename PR (#116) which this release tracks
- [ ] Reviewer: confirm "Create a merge commit" is selected (not rebase/squash)
- [ ] After merge: GitHub Release created → `publish.yml` succeeds → `@agnt-rcpt/openclaw@0.5.0` on npm