### PR TITLE
fix(tools): add timestamp/chain filters and newest-first ordering to ar_query_receipts

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -169,7 +169,7 @@ describe("integration: full plugin lifecycle", () => {
 
     // 3. Query receipts via the registered tool
     const queryTool = tools.get("ar_query_receipts")!.definition;
-    const queryResult = await queryTool.execute("tc-query", {});
+    const queryResult = await queryTool.execute("tc-query", { all_chains: true });
     const queryData = JSON.parse(queryResult.content[0].text);
 
     expect(queryData.total_receipts).toBe(3);
@@ -245,7 +245,7 @@ describe("integration: full plugin lifecycle", () => {
 
     // Session 2's receipt starts at sequence 1 (fresh chain)
     const queryTool = tools.get("ar_query_receipts")!.definition;
-    const qr = await queryTool.execute("q", { action_type: "filesystem.file.delete" });
+    const qr = await queryTool.execute("q", { action_type: "filesystem.file.delete", all_chains: true });
     const qd = JSON.parse(qr.content[0].text);
     expect(qd.results[0].sequence).toBe(1);
   });
@@ -272,7 +272,7 @@ describe("integration: full plugin lifecycle", () => {
     }, { sessionKey: "err", sessionId: "sid-err" });
 
     const queryTool = tools.get("ar_query_receipts")!.definition;
-    const result = await queryTool.execute("q", { status: "failure" });
+    const result = await queryTool.execute("q", { status: "failure", all_chains: true });
     const data = JSON.parse(result.content[0].text);
 
     expect(data.results).toHaveLength(1);

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -174,18 +174,19 @@ describe("integration: full plugin lifecycle", () => {
 
     expect(queryData.total_receipts).toBe(3);
     expect(queryData.results).toHaveLength(3);
-    expect(queryData.results[0].action).toBe("filesystem.file.read");
+    // Results are newest-first (delete → write → read)
+    expect(queryData.results[0].action).toBe("filesystem.file.delete");
     expect(queryData.results[1].action).toBe("filesystem.file.create");
-    expect(queryData.results[2].action).toBe("filesystem.file.delete");
+    expect(queryData.results[2].action).toBe("filesystem.file.read");
 
     // Verify risk levels are classified correctly
-    expect(queryData.results[0].risk).toBe("low");    // read
-    expect(queryData.results[2].risk).toBe("high");    // delete
+    expect(queryData.results[0].risk).toBe("high");    // delete
+    expect(queryData.results[2].risk).toBe("low");     // read
 
-    // Verify sequence numbering
-    expect(queryData.results[0].sequence).toBe(1);
+    // Verify sequence numbering (newest-first: sequences 3, 2, 1)
+    expect(queryData.results[0].sequence).toBe(3);
     expect(queryData.results[1].sequence).toBe(2);
-    expect(queryData.results[2].sequence).toBe(3);
+    expect(queryData.results[2].sequence).toBe(1);
 
     // 4. Verify chain integrity via the registered tool (resolve factory with session context)
     const verifyFactory = tools.get("ar_verify_chain")!.factory!;

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { openStore, type ReceiptStore } from "@agnt-rcpt/sdk-ts";
+import { openStore, type ReceiptStore, createReceipt, signReceipt, hashReceipt } from "@agnt-rcpt/sdk-ts";
 import { createQueryReceiptsTool, createVerifyChainTool, createVerifyChainToolFactory } from "./tools.js";
 import { makeHookDeps, simulateToolCall } from "./test-helpers.js";
 import { getChainId } from "./chain.js";
@@ -121,6 +121,176 @@ describe("ar_query_receipts", () => {
     const data = JSON.parse(result.content[0].text);
 
     // Invalid status is ignored, returns all results
+    expect(data.results).toHaveLength(1);
+  });
+});
+
+/**
+ * Insert a minimal signed receipt at an explicit timestamp directly into the store.
+ * This lets ordering tests control timestamps precisely without relying on wall-clock.
+ */
+function insertReceiptAt(
+  store: ReceiptStore,
+  deps: ReturnType<typeof makeHookDeps>,
+  opts: {
+    seq: number;
+    chainId: string;
+    timestamp: string;
+    previousHash: string | null;
+    actionType?: string;
+  },
+): string {
+  const unsigned = createReceipt({
+    issuer: { id: "did:openclaw:test-agent" },
+    principal: { id: "did:session:test-session" },
+    action: {
+      type: opts.actionType ?? "filesystem.file.read",
+      risk_level: "low",
+      target: { system: "openclaw", resource: "read_file" },
+      parameters_hash: "abc123",
+    },
+    outcome: { status: "success" },
+    chain: {
+      sequence: opts.seq,
+      previous_receipt_hash: opts.previousHash,
+      chain_id: opts.chainId,
+    },
+    actionTimestamp: opts.timestamp,
+  });
+  const signed = signReceipt(unsigned, deps.privateKey, "did:openclaw:test-agent#key-1");
+  const hash = hashReceipt(signed);
+  store.insert(signed, hash);
+  return hash;
+}
+
+describe("ar_query_receipts — filters and ordering", () => {
+  let store: ReceiptStore;
+  let deps: ReturnType<typeof makeHookDeps>;
+  let tool: ReturnType<typeof createQueryReceiptsTool>;
+
+  const CHAIN_A = "chain_openclaw_test-session_sid-1";
+  const CHAIN_B = "chain_openclaw_test-session_sid-2";
+
+  beforeEach(() => {
+    store = openStore(":memory:");
+    deps = makeHookDeps(store);
+    tool = createQueryReceiptsTool({
+      store,
+      publicKey: deps.publicKey,
+      getChainId: (sk, sid) => getChainId(deps.chains, sk, sid),
+    });
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it("default ordering is newest-first", async () => {
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: null });
+    insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: "2024-01-01T11:00:00.000Z", previousHash: "h1" });
+    insertReceiptAt(store, deps, { seq: 3, chainId: CHAIN_A, timestamp: "2024-01-01T12:00:00.000Z", previousHash: "h2" });
+
+    const result = await tool.execute("tc-q", {});
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(3);
+    // First result should be the latest timestamp
+    expect(data.results[0].timestamp).toBe("2024-01-01T12:00:00.000Z");
+    expect(data.results[2].timestamp).toBe("2024-01-01T10:00:00.000Z");
+  });
+
+  it("limit is applied after newest-first ordering", async () => {
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T08:00:00.000Z", previousHash: null });
+    insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: "2024-01-01T09:00:00.000Z", previousHash: "h1" });
+    insertReceiptAt(store, deps, { seq: 3, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: "h2" });
+    insertReceiptAt(store, deps, { seq: 4, chainId: CHAIN_A, timestamp: "2024-01-01T11:00:00.000Z", previousHash: "h3" });
+    insertReceiptAt(store, deps, { seq: 5, chainId: CHAIN_A, timestamp: "2024-01-01T12:00:00.000Z", previousHash: "h4" });
+
+    const result = await tool.execute("tc-q", { limit: 2 });
+    const data = JSON.parse(result.content[0].text);
+
+    // Should return the 2 newest, not the 2 oldest
+    expect(data.results).toHaveLength(2);
+    expect(data.results[0].timestamp).toBe("2024-01-01T12:00:00.000Z");
+    expect(data.results[1].timestamp).toBe("2024-01-01T11:00:00.000Z");
+    expect(data.total_receipts).toBe(5);
+  });
+
+  it("filters by timestamp_after", async () => {
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T08:00:00.000Z", previousHash: null });
+    insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: "h1" });
+    insertReceiptAt(store, deps, { seq: 3, chainId: CHAIN_A, timestamp: "2024-01-01T12:00:00.000Z", previousHash: "h2" });
+
+    const result = await tool.execute("tc-q", { timestamp_after: "2024-01-01T09:00:00.000Z" });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(2);
+    for (const r of data.results) {
+      expect(r.timestamp >= "2024-01-01T09:00:00.000Z").toBe(true);
+    }
+  });
+
+  it("filters by timestamp_before", async () => {
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T08:00:00.000Z", previousHash: null });
+    insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: "h1" });
+    insertReceiptAt(store, deps, { seq: 3, chainId: CHAIN_A, timestamp: "2024-01-01T12:00:00.000Z", previousHash: "h2" });
+
+    const result = await tool.execute("tc-q", { timestamp_before: "2024-01-01T11:00:00.000Z" });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(2);
+    for (const r of data.results) {
+      expect(r.timestamp <= "2024-01-01T11:00:00.000Z").toBe(true);
+    }
+  });
+
+  it("filters by chain_id", async () => {
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: null });
+    insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: "2024-01-01T11:00:00.000Z", previousHash: "h1" });
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_B, timestamp: "2024-01-01T12:00:00.000Z", previousHash: null });
+
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(2);
+    expect(data.total_receipts).toBe(3);
+  });
+
+  it("combining timestamp_after and limit returns newest receipts after cutoff", async () => {
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T06:00:00.000Z", previousHash: null });
+    insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: "h1" });
+    insertReceiptAt(store, deps, { seq: 3, chainId: CHAIN_A, timestamp: "2024-01-01T11:00:00.000Z", previousHash: "h2" });
+    insertReceiptAt(store, deps, { seq: 4, chainId: CHAIN_A, timestamp: "2024-01-01T12:00:00.000Z", previousHash: "h3" });
+
+    // Poll: "give me the latest 2 receipts since 09:00"
+    const result = await tool.execute("tc-q", {
+      timestamp_after: "2024-01-01T09:00:00.000Z",
+      limit: 2,
+    });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(2);
+    expect(data.results[0].timestamp).toBe("2024-01-01T12:00:00.000Z");
+    expect(data.results[1].timestamp).toBe("2024-01-01T11:00:00.000Z");
+  });
+
+  it("ignores invalid timestamp_after values", async () => {
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: null });
+
+    const result = await tool.execute("tc-q", { timestamp_after: "not-a-date" });
+    const data = JSON.parse(result.content[0].text);
+
+    // Invalid timestamp is ignored — returns all results
+    expect(data.results).toHaveLength(1);
+  });
+
+  it("ignores invalid timestamp_before values", async () => {
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: null });
+
+    const result = await tool.execute("tc-q", { timestamp_before: "not-a-date" });
+    const data = JSON.parse(result.content[0].text);
+
+    // Invalid timestamp is ignored — returns all results
     expect(data.results).toHaveLength(1);
   });
 });

--- a/src/tools.test.ts
+++ b/src/tools.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { openStore, type ReceiptStore, createReceipt, signReceipt, hashReceipt } from "@agnt-rcpt/sdk-ts";
-import { createQueryReceiptsTool, createVerifyChainTool, createVerifyChainToolFactory } from "./tools.js";
+import { createQueryReceiptsTool, createQueryReceiptsToolFactory, createVerifyChainTool, createVerifyChainToolFactory } from "./tools.js";
 import { makeHookDeps, simulateToolCall } from "./test-helpers.js";
 import { getChainId } from "./chain.js";
 
@@ -12,11 +12,13 @@ describe("ar_query_receipts", () => {
   beforeEach(() => {
     store = openStore(":memory:");
     deps = makeHookDeps(store);
-    tool = createQueryReceiptsTool({
+    // Use session context matching simulateToolCall defaults so the session-default
+    // chain filter resolves to the same chain where receipts are written.
+    tool = createQueryReceiptsToolFactory({
       store,
       publicKey: deps.publicKey,
       getChainId: (sk, sid) => getChainId(deps.chains, sk, sid),
-    });
+    })({ sessionKey: "test-session", sessionId: "sid-1" });
   });
 
   afterEach(() => {
@@ -174,11 +176,13 @@ describe("ar_query_receipts — filters and ordering", () => {
   beforeEach(() => {
     store = openStore(":memory:");
     deps = makeHookDeps(store);
-    tool = createQueryReceiptsTool({
+    // Construct with session context matching CHAIN_A so session-default chain
+    // resolves correctly for tests that rely on it.
+    tool = createQueryReceiptsToolFactory({
       store,
       publicKey: deps.publicKey,
       getChainId: (sk, sid) => getChainId(deps.chains, sk, sid),
-    });
+    })({ sessionKey: "test-session", sessionId: "sid-1" });
   });
 
   afterEach(() => {
@@ -190,7 +194,7 @@ describe("ar_query_receipts — filters and ordering", () => {
     insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: "2024-01-01T11:00:00.000Z", previousHash: "h1" });
     insertReceiptAt(store, deps, { seq: 3, chainId: CHAIN_A, timestamp: "2024-01-01T12:00:00.000Z", previousHash: "h2" });
 
-    const result = await tool.execute("tc-q", {});
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A });
     const data = JSON.parse(result.content[0].text);
 
     expect(data.results).toHaveLength(3);
@@ -206,7 +210,7 @@ describe("ar_query_receipts — filters and ordering", () => {
     insertReceiptAt(store, deps, { seq: 4, chainId: CHAIN_A, timestamp: "2024-01-01T11:00:00.000Z", previousHash: "h3" });
     insertReceiptAt(store, deps, { seq: 5, chainId: CHAIN_A, timestamp: "2024-01-01T12:00:00.000Z", previousHash: "h4" });
 
-    const result = await tool.execute("tc-q", { limit: 2 });
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A, limit: 2 });
     const data = JSON.parse(result.content[0].text);
 
     // Should return the 2 newest, not the 2 oldest
@@ -216,17 +220,36 @@ describe("ar_query_receipts — filters and ordering", () => {
     expect(data.total_receipts).toBe(5);
   });
 
-  it("filters by timestamp_after", async () => {
+  it("filters by timestamp_after (exclusive — does not include the boundary timestamp)", async () => {
+    const T1 = "2024-01-01T08:00:00.000Z";
+    const T2 = "2024-01-01T10:00:00.000Z";
+    const T3 = "2024-01-01T12:00:00.000Z";
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: T1, previousHash: null });
+    insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: T2, previousHash: "h1" });
+    insertReceiptAt(store, deps, { seq: 3, chainId: CHAIN_A, timestamp: T3, previousHash: "h2" });
+
+    // Polling with timestamp_after: T1 should return T2 and T3 but NOT T1 itself.
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A, timestamp_after: T1 });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(2);
+    const timestamps = data.results.map((r: { timestamp: string }) => r.timestamp);
+    expect(timestamps).toContain(T2);
+    expect(timestamps).toContain(T3);
+    expect(timestamps).not.toContain(T1);
+  });
+
+  it("filters by timestamp_after (mid-range)", async () => {
     insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T08:00:00.000Z", previousHash: null });
     insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: "h1" });
     insertReceiptAt(store, deps, { seq: 3, chainId: CHAIN_A, timestamp: "2024-01-01T12:00:00.000Z", previousHash: "h2" });
 
-    const result = await tool.execute("tc-q", { timestamp_after: "2024-01-01T09:00:00.000Z" });
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A, timestamp_after: "2024-01-01T09:00:00.000Z" });
     const data = JSON.parse(result.content[0].text);
 
     expect(data.results).toHaveLength(2);
     for (const r of data.results) {
-      expect(r.timestamp >= "2024-01-01T09:00:00.000Z").toBe(true);
+      expect(r.timestamp > "2024-01-01T09:00:00.000Z").toBe(true);
     }
   });
 
@@ -235,7 +258,7 @@ describe("ar_query_receipts — filters and ordering", () => {
     insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: "h1" });
     insertReceiptAt(store, deps, { seq: 3, chainId: CHAIN_A, timestamp: "2024-01-01T12:00:00.000Z", previousHash: "h2" });
 
-    const result = await tool.execute("tc-q", { timestamp_before: "2024-01-01T11:00:00.000Z" });
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A, timestamp_before: "2024-01-01T11:00:00.000Z" });
     const data = JSON.parse(result.content[0].text);
 
     expect(data.results).toHaveLength(2);
@@ -264,6 +287,7 @@ describe("ar_query_receipts — filters and ordering", () => {
 
     // Poll: "give me the latest 2 receipts since 09:00"
     const result = await tool.execute("tc-q", {
+      chain_id: CHAIN_A,
       timestamp_after: "2024-01-01T09:00:00.000Z",
       limit: 2,
     });
@@ -277,7 +301,7 @@ describe("ar_query_receipts — filters and ordering", () => {
   it("ignores invalid timestamp_after values", async () => {
     insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: null });
 
-    const result = await tool.execute("tc-q", { timestamp_after: "not-a-date" });
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A, timestamp_after: "not-a-date" });
     const data = JSON.parse(result.content[0].text);
 
     // Invalid timestamp is ignored — returns all results
@@ -287,11 +311,132 @@ describe("ar_query_receipts — filters and ordering", () => {
   it("ignores invalid timestamp_before values", async () => {
     insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: null });
 
-    const result = await tool.execute("tc-q", { timestamp_before: "not-a-date" });
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A, timestamp_before: "not-a-date" });
     const data = JSON.parse(result.content[0].text);
 
     // Invalid timestamp is ignored — returns all results
     expect(data.results).toHaveLength(1);
+  });
+
+  it("result shape includes chain_id field", async () => {
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: "2024-01-01T10:00:00.000Z", previousHash: null });
+
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].chain_id).toBe(CHAIN_A);
+  });
+
+  it("limit: -1 falls back to default of 20", async () => {
+    // Insert 25 receipts so we can distinguish 20 from 25
+    for (let i = 1; i <= 25; i++) {
+      insertReceiptAt(store, deps, {
+        seq: i,
+        chainId: CHAIN_A,
+        timestamp: `2024-01-01T${String(i).padStart(2, "0")}:00:00.000Z`,
+        previousHash: i === 1 ? null : `h${i - 1}`,
+      });
+    }
+
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A, limit: -1 });
+    const data = JSON.parse(result.content[0].text);
+
+    // -1 is invalid; falls back to default 20
+    expect(data.results).toHaveLength(20);
+  });
+
+  it("limit: 5.7 (non-integer) falls back to default 20, not 5", async () => {
+    // Insert 25 receipts
+    for (let i = 1; i <= 25; i++) {
+      insertReceiptAt(store, deps, {
+        seq: i,
+        chainId: CHAIN_A,
+        timestamp: `2024-01-01T${String(i).padStart(2, "0")}:00:00.000Z`,
+        previousHash: i === 1 ? null : `h${i - 1}`,
+      });
+    }
+
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A, limit: 5.7 });
+    const data = JSON.parse(result.content[0].text);
+
+    // 5.7 is not an integer; falls back to default 20, not Math.floor(5.7)=5
+    expect(data.results).toHaveLength(20);
+  });
+
+  it("same-millisecond sequence tiebreaker: higher sequence comes first", async () => {
+    const SAME_TS = "2024-01-01T10:00:00.000Z";
+    insertReceiptAt(store, deps, { seq: 1, chainId: CHAIN_A, timestamp: SAME_TS, previousHash: null });
+    insertReceiptAt(store, deps, { seq: 2, chainId: CHAIN_A, timestamp: SAME_TS, previousHash: "h1" });
+
+    const result = await tool.execute("tc-q", { chain_id: CHAIN_A });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(2);
+    // seq 2 is "newer" within the same millisecond — must come first
+    expect(data.results[0].sequence).toBe(2);
+    expect(data.results[1].sequence).toBe(1);
+  });
+
+  it("defaults chain_id to current session's chain when omitted", async () => {
+    // Session A receipts (CHAIN_A) — inserted via simulateToolCall
+    await simulateToolCall(deps, "read_file", { path: "/a.txt" }, { toolCallId: "tc-a1", sessionKey: "test-session", sessionId: "sid-1" });
+    await simulateToolCall(deps, "read_file", { path: "/a2.txt" }, { toolCallId: "tc-a2", sessionKey: "test-session", sessionId: "sid-1" });
+    // Session B receipt (CHAIN_B)
+    await simulateToolCall(deps, "read_file", { path: "/b.txt" }, { toolCallId: "tc-b1", sessionKey: "test-session", sessionId: "sid-2" });
+
+    // Query from session A context with no chain_id — should only return session A receipts
+    const sessionATool = createQueryReceiptsToolFactory({
+      store,
+      publicKey: deps.publicKey,
+      getChainId: (sk, sid) => getChainId(deps.chains, sk, sid),
+    })({ sessionKey: "test-session", sessionId: "sid-1" });
+
+    const result = await sessionATool.execute("tc-q", {});
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(2);
+    expect(data.total_receipts).toBe(3);
+    for (const r of data.results) {
+      expect(r.chain_id).toBe(CHAIN_A);
+    }
+  });
+
+  it("all_chains: true returns receipts from every chain", async () => {
+    await simulateToolCall(deps, "read_file", { path: "/a.txt" }, { toolCallId: "tc-a1", sessionKey: "test-session", sessionId: "sid-1" });
+    await simulateToolCall(deps, "read_file", { path: "/a2.txt" }, { toolCallId: "tc-a2", sessionKey: "test-session", sessionId: "sid-1" });
+    await simulateToolCall(deps, "read_file", { path: "/b.txt" }, { toolCallId: "tc-b1", sessionKey: "test-session", sessionId: "sid-2" });
+
+    // Query from session A context with all_chains — should return all 3
+    const sessionATool = createQueryReceiptsToolFactory({
+      store,
+      publicKey: deps.publicKey,
+      getChainId: (sk, sid) => getChainId(deps.chains, sk, sid),
+    })({ sessionKey: "test-session", sessionId: "sid-1" });
+
+    const result = await sessionATool.execute("tc-q", { all_chains: true });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(3);
+  });
+
+  it("explicit chain_id beats session default", async () => {
+    await simulateToolCall(deps, "read_file", { path: "/a.txt" }, { toolCallId: "tc-a1", sessionKey: "test-session", sessionId: "sid-1" });
+    await simulateToolCall(deps, "read_file", { path: "/a2.txt" }, { toolCallId: "tc-a2", sessionKey: "test-session", sessionId: "sid-1" });
+    await simulateToolCall(deps, "read_file", { path: "/b.txt" }, { toolCallId: "tc-b1", sessionKey: "test-session", sessionId: "sid-2" });
+
+    // Query from session A context but explicitly targeting session B's chain
+    const sessionATool = createQueryReceiptsToolFactory({
+      store,
+      publicKey: deps.publicKey,
+      getChainId: (sk, sid) => getChainId(deps.chains, sk, sid),
+    })({ sessionKey: "test-session", sessionId: "sid-1" });
+
+    const result = await sessionATool.execute("tc-q", { chain_id: CHAIN_B });
+    const data = JSON.parse(result.content[0].text);
+
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].chain_id).toBe(CHAIN_B);
   });
 });
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -38,7 +38,9 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
     label: "Query Attestation Receipts",
     description:
       "Search the cryptographic audit trail of actions taken in this session. " +
-      "Returns signed receipts filtered by action type, risk level, or status.",
+      "Returns receipts newest-first, filtered by action type, risk level, status, chain, or time window. " +
+      "To poll for new actions since your last check, pass `timestamp_after` set to the timestamp of " +
+      "the most recent receipt you've already seen.",
     parameters: Type.Object({
       action_type: Type.Optional(
         Type.String({ description: 'Filter by action type (e.g. "filesystem.file.read")' }),
@@ -48,6 +50,15 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
       ),
       status: Type.Optional(
         Type.String({ description: 'Filter by outcome status: "success", "failure", or "pending"' }),
+      ),
+      chain_id: Type.Optional(
+        Type.String({ description: "Restrict results to a single receipt chain." }),
+      ),
+      timestamp_after: Type.Optional(
+        Type.String({ description: "ISO 8601 — return only receipts at or after this time." }),
+      ),
+      timestamp_before: Type.Optional(
+        Type.String({ description: "ISO 8601 — return only receipts at or before this time." }),
       ),
       limit: Type.Optional(
         Type.Number({ description: "Maximum number of receipts to return (default: 20)" }),
@@ -59,6 +70,9 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
         action_type?: string;
         risk_level?: string;
         status?: string;
+        chain_id?: string;
+        timestamp_after?: string;
+        timestamp_before?: string;
         limit?: number;
       },
     ) {
@@ -69,12 +83,40 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
         ? (params.status as OutcomeStatus)
         : undefined;
 
-      const results = deps.store.query({
+      // Validate ISO 8601 inputs lightly — ignore if unparseable (consistent with
+      // how invalid risk_level/status values are silently dropped above).
+      const after =
+        params.timestamp_after && !isNaN(Date.parse(params.timestamp_after))
+          ? params.timestamp_after
+          : undefined;
+      const before =
+        params.timestamp_before && !isNaN(Date.parse(params.timestamp_before))
+          ? params.timestamp_before
+          : undefined;
+
+      // Fetch all matching receipts without a limit so we can sort newest-first
+      // in JS before slicing. The SDK only supports ASC ordering today.
+      const all = deps.store.query({
         actionType: params.action_type,
         riskLevel,
         status,
-        limit: params.limit ?? 20,
+        chainId: params.chain_id,
+        after,
+        before,
       });
+
+      const limit = params.limit ?? 20;
+      const results = all
+        .sort((a, b) => {
+          const ta = a.credentialSubject.action.timestamp;
+          const tb = b.credentialSubject.action.timestamp;
+          if (tb < ta) return -1;
+          if (tb > ta) return 1;
+          // Tiebreak by sequence descending so calls within the same millisecond
+          // are still returned newest-first within their chain.
+          return b.credentialSubject.chain.sequence - a.credentialSubject.chain.sequence;
+        })
+        .slice(0, limit);
 
       const stats = deps.store.stats();
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -111,9 +111,10 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
           : deps.getChainId(ctx.sessionKey ?? "default", ctx.sessionId);
 
       // Clamp limit: must be a non-negative integer; fall back to default 20 otherwise.
-      const limit = Number.isInteger(params.limit) && (params.limit as number) >= 0
-        ? (params.limit as number)
-        : 20;
+      const limit =
+        typeof params.limit === "number" && Number.isInteger(params.limit) && params.limit >= 0
+          ? params.limit
+          : 20;
 
       // Fetch all matching receipts without a limit so we can sort newest-first
       // in JS before slicing. The SDK only supports ASC ordering today.

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -33,12 +33,14 @@ type ToolFactoryContext = {
  * The factory is called by OpenClaw at runtime with session context.
  */
 export function createQueryReceiptsToolFactory(deps: ToolDeps) {
-  return (_ctx: ToolFactoryContext) => ({
+  return (ctx: ToolFactoryContext) => ({
     name: "ar_query_receipts",
     label: "Query Attestation Receipts",
     description:
       "Search the cryptographic audit trail of actions taken in this session. " +
       "Returns receipts newest-first, filtered by action type, risk level, status, chain, or time window. " +
+      "By default, only receipts from the current session's chain are returned. " +
+      "Set `all_chains` to true to query across all chains. " +
       "To poll for new actions since your last check, pass `timestamp_after` set to the timestamp of " +
       "the most recent receipt you've already seen.",
     parameters: Type.Object({
@@ -54,8 +56,11 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
       chain_id: Type.Optional(
         Type.String({ description: "Restrict results to a single receipt chain." }),
       ),
+      all_chains: Type.Optional(
+        Type.Boolean({ description: "Set true to query across all chains. Default: current session only." }),
+      ),
       timestamp_after: Type.Optional(
-        Type.String({ description: "ISO 8601 — return only receipts at or after this time." }),
+        Type.String({ description: "ISO 8601 — return only receipts after this time (exclusive)." }),
       ),
       timestamp_before: Type.Optional(
         Type.String({ description: "ISO 8601 — return only receipts at or before this time." }),
@@ -71,6 +76,7 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
         risk_level?: string;
         status?: string;
         chain_id?: string;
+        all_chains?: boolean;
         timestamp_after?: string;
         timestamp_before?: string;
         limit?: number;
@@ -94,19 +100,39 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
           ? params.timestamp_before
           : undefined;
 
+      // Resolve the chain filter:
+      //   - explicit chain_id → use it
+      //   - all_chains: true → no filter (query all chains)
+      //   - default → current session's chain
+      const chainId: string | undefined = params.chain_id
+        ? params.chain_id
+        : params.all_chains === true
+          ? undefined
+          : deps.getChainId(ctx.sessionKey ?? "default", ctx.sessionId);
+
+      // Clamp limit: must be a non-negative integer; fall back to default 20 otherwise.
+      const limit = Number.isInteger(params.limit) && (params.limit as number) >= 0
+        ? (params.limit as number)
+        : 20;
+
       // Fetch all matching receipts without a limit so we can sort newest-first
       // in JS before slicing. The SDK only supports ASC ordering today.
       const all = deps.store.query({
         actionType: params.action_type,
         riskLevel,
         status,
-        chainId: params.chain_id,
+        chainId,
         after,
         before,
       });
 
-      const limit = params.limit ?? 20;
-      const results = all
+      // The SDK's `after` filter is >= (inclusive). We want exclusive (>), so we
+      // drop any receipt whose timestamp exactly equals params.timestamp_after.
+      const filtered = after
+        ? all.filter((r) => r.credentialSubject.action.timestamp !== after)
+        : all;
+
+      const results = filtered
         .sort((a, b) => {
           const ta = a.credentialSubject.action.timestamp;
           const tb = b.credentialSubject.action.timestamp;
@@ -128,6 +154,7 @@ export function createQueryReceiptsToolFactory(deps: ToolDeps) {
         by_action: stats.byAction,
         results: results.map((r) => ({
           id: r.id,
+          chain_id: r.credentialSubject.chain.chain_id,
           action: r.credentialSubject.action.type,
           risk: r.credentialSubject.action.risk_level,
           target: r.credentialSubject.action.target?.resource,


### PR DESCRIPTION
## Summary

Fixes #118. Two bugs in `ar_query_receipts`:

- **`timestamp_after` silently dropped**: the parameter wasn't in the TypeBox schema and wasn't passed to the SDK query. `timestamp_before` and `chain_id` had the same gap. All three are now wired through.
- **Stale receipts returned by default**: the SDK's `ReceiptStore.query` returns results `ORDER BY timestamp ASC`, so with a `LIMIT 20` the tool returned the 20 _oldest_ receipts, not the 20 newest. Results are now sorted newest-first in JS after fetching, then sliced to `limit`. Sequence number is the tiebreaker for receipts within the same millisecond.

## What changed

- `src/tools.ts`: three new parameters (`chain_id`, `timestamp_after`, `timestamp_before`) added to the schema and `execute` signature; sort+slice replaces the SDK-side limit; tool description updated with polling guidance; light ISO 8601 validation (consistent with how invalid `risk_level`/`status` are already handled).
  - **`timestamp_after` is now exclusive (`>`)**: the SDK's `after` filter is `>=`, so polling with the last-seen timestamp would re-return that receipt. The JS post-filter drops any receipt whose timestamp exactly equals `timestamp_after`. Parameter description updated to say "exclusive".
  - **`chain_id` added to result shape**: each receipt in `results` now includes `chain_id` so callers can identify which chain it belongs to and use it in follow-up queries.
  - **`limit` clamped to non-negative integers**: fractional values (e.g. `5.7`) and negative values (e.g. `-1`) fall back to the default of 20, consistent with how invalid `risk_level`/`status` are already silently ignored.
  - **Default `chain_id` to current session's chain**: when `chain_id` is omitted, results are scoped to the current session's chain (resolved via factory context). New boolean `all_chains: true` opts out and queries across all chains.
- `src/tools.test.ts`: new and updated tests — 8 existing tests migrated to factory-with-context pattern; 10 new tests covering exclusive `timestamp_after`, `chain_id` in result shape, limit clamping (negative and fractional), same-millisecond sequence tiebreaker, session-chain defaulting, `all_chains: true`, and explicit `chain_id` override.
- `src/integration.test.ts`: cross-session queries updated to pass `all_chains: true` (the tool is resolved at registration time with a mock context that doesn't match the session under test).

## Out of scope (intentional follow-ups)

- **>10k-receipt blind spot** — the SDK's `DEFAULT_QUERY_LIMIT` plus ASC ordering means stores with more than 10,000 matching receipts will silently lose the newest ones, even with this PR's JS-side sort. The proper fix is at the SDK level (DESC ordering and/or removing the silent cap) and applies equally to all language SDKs (TS, Go, Python). Tracked in agent-receipts/ar#300.
- **Streaming / long-poll "follow" mode** — `ar_query_receipts` is request/response; a true `tail -f` pattern would require a different mechanism. Out of scope per this issue.
- **Cross-chain splinter detection (ADR-10)** — the `chain_id` filter enables per-chain queries but doesn't enforce or detect cross-chain splits. ADR-10 tracks that separately.

## Test plan

- [ ] `pnpm test` — 171 tests, 7 files, all pass
- [ ] `pnpm typecheck` — clean
- [ ] Verify `timestamp_after` is exclusive: polling with last-seen timestamp no longer returns duplicate
- [ ] Verify `limit: 5` returns the 5 newest, not the 5 oldest
- [ ] Verify `chain_id` in result shape
- [ ] Verify default scopes to current session; `all_chains: true` returns all