### PR TITLE
chore: prep v0.6.0 changelog and gitignore Claude Code state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ dist/
 package-lock.json
 keys.json
 *-recording.txt
+
+# Claude Code local session state (project-level settings.json and hooks/ are tracked)
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (breaking)
+- **`ar_query_receipts` now defaults to the current session's chain** instead
+  of querying every chain in the store. Pass `all_chains: true` to restore the
+  prior global-query behavior. Cross-session audit callers should opt in
+  explicitly (#118, #119).
+
+### Fixed
+- `ar_query_receipts` respects `timestamp_after` — previously the parameter
+  was missing from the tool schema, so it was silently dropped before reaching
+  the SDK and stale receipts were returned (#118).
+- `ar_query_receipts` returns the *newest* receipts by default. The SDK's
+  underlying query orders ASC, so the prior `limit: 20` returned the 20
+  oldest receipts in larger sessions, making real-time auditing impossible
+  (#118).
+- `limit` parameter is clamped — negative or fractional values fall back to
+  the default 20 instead of producing surprising slices like "all-but-last".
+
+### Added
+- New `ar_query_receipts` filters: `chain_id`, `timestamp_after` (exclusive),
+  `timestamp_before` (inclusive), `all_chains`.
+- Result objects now include `chain_id` so callers can identify the source
+  chain and reuse it in follow-up queries.
+- Polling guidance in the tool description: pass `timestamp_after` set to the
+  timestamp of the last receipt you've seen.
+
+### Known limitations
+- Stores with >10,000 matching receipts may miss the newest results
+  (SDK-level default cap). Tracked in
+  [agent-receipts/ar#300](https://github.com/agent-receipts/ar/issues/300).
+- Same-millisecond bursts beyond `limit` can drop unread receipts during
+  polling. Tracked in [#121](https://github.com/agent-receipts/openclaw/issues/121).
+- Exclusive `timestamp_after` filter compares ISO 8601 strings byte-wise, not
+  instant-wise. Tracked in [#122](https://github.com/agent-receipts/openclaw/issues/122).
+
 ## [0.5.0] - 2026-05-01
 
 ### Changed (breaking)


### PR DESCRIPTION
## Summary

Prep PR for the v0.6.0 release. Lands the CHANGELOG entry and an unrelated-but-blocking `.gitignore` patch so `scripts/release.sh` can run cleanly afterward.

## Why this is a separate PR

`scripts/release.sh` requires (a) clean working tree and (b) local main not ahead of origin. With branch protection on `main`, neither prep commits nor the release commit itself can be pushed directly. Same pattern PR #117 used for v0.5.0: land CHANGELOG additions in a regular PR, then run the release script on a clean main.

## What's in here

- **`.gitignore`** — ignore three Claude Code local-session paths (`settings.local.json`, `scheduled_tasks.lock`, `worktrees/`). Project-level `.claude/settings.json` and `.claude/hooks/` remain tracked.
- **`CHANGELOG.md`** — populate `[Unreleased]` with the changes from #119:
  - Breaking: `ar_query_receipts` defaults to current session's chain (use `all_chains: true` to opt out)
  - Fixed: `timestamp_after` no longer dropped, newest-first ordering, `limit` clamping
  - Added: `chain_id`/`timestamp_after`/`timestamp_before`/`all_chains` filters; `chain_id` in result objects; polling guidance in tool description
  - Known limitations: links to agent-receipts/ar#300 (SDK cap), #121 (same-ms burst), #122 (instant equality)

No code changes.

## Next step

After this merges, run `scripts/release.sh minor` on a fresh main checkout to produce the actual v0.6.0 release PR.

## Test plan

- [ ] CI passes (no source code touched, but lefthook/conventional-commit checks should still pass)