### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-02
+
 ### Changed (breaking)
 - **`ar_query_receipts` now defaults to the current session's chain** instead
   of querying every chain in the store. Pass `all_chains: true` to restore the
@@ -155,7 +157,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security hardening: key file permissions, input validation, pending-map memory
   leak prevention (#22).
 
-[Unreleased]: https://github.com/agent-receipts/openclaw/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/agent-receipts/openclaw/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/agent-receipts/openclaw/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/agent-receipts/openclaw/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/agent-receipts/openclaw/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/agent-receipts/openclaw/compare/v0.3.2...v0.3.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Release commit for **v0.6.0** — promotes `[Unreleased]` to `[0.6.0]` and bumps `package.json` to `0.6.0`.

Tracks #118 / #119 (`ar_query_receipts` filter, ordering, and chain-default fixes). The full bullet list is already on `main` in `CHANGELOG.md`.

## Why this is a separate PR

`scripts/release.sh` tried `git push origin main v0.6.0` which the branch protection on `main` rejected (PRs required). The tag `v0.6.0` was already accepted on the remote and points at the commit on this branch (`c7c7075`), so we need to land this exact SHA on `main`.

## Merge strategy

**Use "Create a merge commit"** — preserves the commit SHA so tag `v0.6.0` stays reachable from `main`'s history. Rebase or squash would change the SHA and orphan the tag.

## After merge

I'll run `gh release create v0.6.0 --generate-notes` to fire `publish.yml` → npm publish.

## Test plan

- [x] CI green on the changes shipped here (the `ar_query_receipts` PR #119 and the prep PR #123 already merged)
- [ ] Reviewer: confirm "Create a merge commit" is selected (not rebase/squash)
- [ ] After merge: GitHub Release created → `publish.yml` succeeds → `@agnt-rcpt/openclaw@0.6.0` on npm