### PR TITLE
ci: route pre-release tags to non-default npm dist-tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,5 +44,18 @@ jobs:
 
       - run: pnpm run build
 
+      # Pre-release versions go to a non-default dist-tag so they don't
+      # clobber `latest` for users on the stable line. Extracts the
+      # pre-release identifier from semver (alpha/beta/rc/...).
+      - name: Determine npm dist-tag
+        id: dist_tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$PKG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-([a-z]+) ]]; then
+            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,14 +45,28 @@ jobs:
       - run: pnpm run build
 
       # Pre-release versions go to a non-default dist-tag so they don't
-      # clobber `latest` for users on the stable line. Extracts the
-      # pre-release identifier from semver (alpha/beta/rc/...).
+      # clobber `latest` for users on the stable line. Two-phase logic:
+      #   1. Strip SemVer build metadata (after '+'); if a '-' remains
+      #      anywhere in the core version, this is a pre-release.
+      #   2. Extract a leading [A-Za-z]+ identifier from the pre-release
+      #      portion (lowercased). Falls back to `prerelease` if the
+      #      identifier is purely numeric or otherwise unparseable —
+      #      never falls through to `latest`, which would defeat the
+      #      whole purpose.
       - name: Determine npm dist-tag
         id: dist_tag
+        shell: bash
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
-          if [[ "$PKG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-([a-z]+) ]]; then
-            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          CORE="${PKG_VERSION%%+*}"
+          if [[ "$CORE" == *-* ]]; then
+            PRE="${CORE#*-}"
+            if [[ "$PRE" =~ ^([A-Za-z]+) ]]; then
+              TAG_NAME="${BASH_REMATCH[1],,}"
+            else
+              TAG_NAME="prerelease"
+            fi
+            echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## What

Detect the pre-release identifier from `package.json` (e.g. `alpha` from `0.8.0-alpha.1`) and pass it as `npm publish --tag <name>`. Stable releases keep going to `latest`; alpha/beta/rc tracks become opt-in via `@agnt-rcpt/openclaw@alpha` and friends.

```diff
       - run: pnpm run build

+      # Pre-release versions go to a non-default dist-tag so they don't
+      # clobber `latest` for users on the stable line. Extracts the
+      # pre-release identifier from semver (alpha/beta/rc/...).
+      - name: Determine npm dist-tag
+        id: dist_tag
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$PKG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-([a-z]+) ]]; then
+            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag ${{ steps.dist_tag.outputs.tag }}
```

## Why

Preparation for the `v0.8.0-alpha.1` daemon-backed cutover ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md), [agent-receipts/ar#236](https://github.com/agent-receipts/ar/issues/236)). Without this change, publishing the alpha would clobber the npm `latest` dist-tag and pull every existing v0.6.x user onto the alpha on their next `npm install`.

## Context

- Mirrors the equivalent change in [agent-receipts/ar#342](https://github.com/agent-receipts/ar/pull/342) (`publish-ts.yml`). Same wire format, same dist-tag extraction.
- The semver capture is constrained to `[a-z]+` so the value reaching `npm publish --tag` is always either a literal `latest` or a lowercase identifier — no shell-metacharacter surface.
- Triggers unchanged: `release: published` and `workflow_dispatch`.
- The release-tag-matches-package.json check above this step is unaffected; pre-release versions are caught by both the existing equality check and the new dist-tag extraction without further regex changes there.

## Verifying

After merge, the next time a `v0.x.0-alpha.N` GitHub Release is cut on this repo, the workflow should:
1. Resolve `tag=alpha` (or `beta`/`rc`) from the regex.
2. Call `npm publish --access public --provenance --tag alpha`.
3. Leave `npm dist-tag ls @agnt-rcpt/openclaw` showing `latest: 0.6.0` (unchanged) and `alpha: 0.x.0-alpha.N` (new).