### PR TITLE
chore(release): bump version to 0.8.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.6.0",
+  "version": "0.8.0-alpha.1",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## What

Bump `@agnt-rcpt/openclaw` from `0.6.0` to `0.8.0-alpha.1`.

## Why

Aligns OpenClaw with the coordinated `v0.8.0-alpha.1` daemon-backed cutover ([ADR-0010](https://github.com/agent-receipts/ar/blob/main/docs/adr/0010-daemon-process-separation.md), tracking issue [agent-receipts/ar#236](https://github.com/agent-receipts/ar/issues/236)).

Skips minor `0.7` deliberately — `mcp-proxy` was already at `0.7.0` before the cutover, so `0.8.0` is the first minor free across the whole stack. From here on, OpenClaw stays lockstep with the ar-side packages until decoupled deliberately.

The pre-release form `0.8.0-alpha.1` will ship to npm under the `@alpha` dist-tag (per [#126](https://github.com/agent-receipts/openclaw/pull/126), already merged); stable users on the `@latest` channel are unaffected.

## After this lands

`git tag v0.8.0-alpha.1 && git push --tags` (or via this repo's `scripts/release.sh`) cuts the alpha to npm under `@agnt-rcpt/openclaw@alpha`, alongside the ar-side tag cuts of the rest of the stack.