### PR TITLE
feat(release): support pre-release versions in release.sh

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -143,7 +143,7 @@ function parse(v) {
       }
     }
   }
-  return { major: +m[1], minor: +m[2], patch: +m[3], pre: m[4] ?? null };
+  return { major: BigInt(m[1]), minor: BigInt(m[2]), patch: BigInt(m[3]), pre: m[4] ?? null };
 }
 // Compare two dot-separated pre-release identifiers per SemVer §11.4
 function comparePre(a, b) {
@@ -162,9 +162,9 @@ function comparePre(a, b) {
 }
 function cmp(a, b) {
   const pa = parse(a), pb = parse(b);
-  if (pa.major !== pb.major) return pa.major - pb.major;
-  if (pa.minor !== pb.minor) return pa.minor - pb.minor;
-  if (pa.patch !== pb.patch) return pa.patch - pb.patch;
+  if (pa.major !== pb.major) return pa.major > pb.major ? 1 : -1;
+  if (pa.minor !== pb.minor) return pa.minor > pb.minor ? 1 : -1;
+  if (pa.patch !== pb.patch) return pa.patch > pb.patch ? 1 : -1;
   if (pa.pre === null && pb.pre === null) return 0;
   if (pa.pre === null) return 1;   // release > pre-release of same X.Y.Z
   if (pb.pre === null) return -1;  // pre-release < release of same X.Y.Z

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,6 +49,23 @@ done
 
 die() { echo "error: $*" >&2; exit 1; }
 
+# Validate a version string: must match SEMVER_RE and must not contain purely
+# numeric pre-release identifiers with leading zeros (SemVer §9).
+# Usage: validate_semver <version> <context>
+validate_semver() {
+  local v="$1" ctx="$2"
+  [[ "$v" =~ $SEMVER_RE ]] \
+    || die "${ctx} '${v}' is not a valid SemVer version (X.Y.Z or X.Y.Z-prerelease)"
+  if [[ "$v" == *-* ]]; then
+    local pre="${v#*-}" id
+    IFS='.' read -ra _ids <<< "$pre"
+    for id in "${_ids[@]}"; do
+      [[ "$id" =~ ^0[0-9]+$ ]] \
+        && die "invalid pre-release identifier '${id}' in '${ctx}' '${v}' — numeric identifiers must not have leading zeros"
+    done
+  fi
+}
+
 # run <cmd> [args...] — execute normally, or just print in dry-run mode
 run() {
   if [[ "$DRY_RUN" == true ]]; then
@@ -85,8 +102,7 @@ fi
 CURRENT_VERSION=$(node -p "require('./package.json').version")
 
 SEMVER_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z][0-9A-Za-z-]*(\.[0-9A-Za-z][0-9A-Za-z-]*)*)?$'
-[[ "$CURRENT_VERSION" =~ $SEMVER_RE ]] \
-  || die "package.json version '${CURRENT_VERSION}' is not a valid SemVer version (X.Y.Z or X.Y.Z-prerelease)"
+validate_semver "$CURRENT_VERSION" "package.json version"
 
 # Extract the stable X.Y.Z base and detect whether we're currently on a pre-release
 CURRENT_BASE="${CURRENT_VERSION%%-*}"
@@ -106,8 +122,7 @@ case "$BUMP" in
     esac
     ;;
   *)
-    [[ "$BUMP" =~ $SEMVER_RE ]] \
-      || die "invalid argument '${BUMP}' — must be patch/minor/major or X.Y.Z[-prerelease]"
+    validate_semver "$BUMP" "version argument"
     NEW_VERSION="$BUMP"
     ;;
 esac

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -119,6 +119,15 @@ node << 'JSEOF'
 function parse(v) {
   const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
   if (!m) { process.stderr.write('error: invalid version: ' + v + '\n'); process.exit(2); }
+  // Purely numeric pre-release identifiers must not have leading zeros (SemVer §9)
+  if (m[4]) {
+    for (const id of m[4].split('.')) {
+      if (/^\d+$/.test(id) && id.length > 1 && id[0] === '0') {
+        process.stderr.write("error: invalid pre-release identifier '" + id + "' in '" + v + "' — numeric identifiers must not have leading zeros\n");
+        process.exit(1);
+      }
+    }
+  }
   return { major: +m[1], minor: +m[2], patch: +m[3], pre: m[4] ?? null };
 }
 // Compare two dot-separated pre-release identifiers per SemVer §11.4

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -84,7 +84,7 @@ fi
 
 CURRENT_VERSION=$(node -p "require('./package.json').version")
 
-SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z-]*(\.[0-9A-Za-z][0-9A-Za-z-]*)*)?$'
+SEMVER_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z][0-9A-Za-z-]*(\.[0-9A-Za-z][0-9A-Za-z-]*)*)?$'
 [[ "$CURRENT_VERSION" =~ $SEMVER_RE ]] \
   || die "package.json version '${CURRENT_VERSION}' is not a valid SemVer version (X.Y.Z or X.Y.Z-prerelease)"
 
@@ -130,7 +130,7 @@ function comparePre(a, b) {
     if (i >= bp.length) return 1;
     const ai = ap[i], bi = bp[i];
     const an = /^\d+$/.test(ai), bn = /^\d+$/.test(bi);
-    if (an && bn) { const d = +ai - +bi; if (d !== 0) return d; }
+    if (an && bn) { if (ai !== bi) return BigInt(ai) > BigInt(bi) ? 1 : -1; }
     else if (an !== bn) { return an ? -1 : 1; } // numeric < alphanumeric
     else { if (ai < bi) return -1; if (ai > bi) return 1; }
   }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,7 +3,7 @@
 # scripts/release.sh — Automate the openclaw release flow
 #
 # Usage:
-#   scripts/release.sh [--dry-run] <patch|minor|major|X.Y.Z>
+#   scripts/release.sh [--dry-run] <patch|minor|major|X.Y.Z[-prerelease]>
 #
 # Steps:
 #   1. Validate preconditions (clean tree, on main, required tools present)
@@ -19,11 +19,11 @@ cd "$(dirname "$0")/.." || { echo "error: cannot change to repo root" >&2; exit 
 # ── Usage ─────────────────────────────────────────────────────────────────────
 
 usage() {
-  echo "Usage: $(basename "$0") [--dry-run] <patch|minor|major|X.Y.Z>" >&2
+  echo "Usage: $(basename "$0") [--dry-run] <patch|minor|major|X.Y.Z[-prerelease]>" >&2
   echo >&2
-  echo "  patch|minor|major  Bump the current version by that increment" >&2
-  echo "  X.Y.Z              Use this exact version" >&2
-  echo "  --dry-run          Print every step; make no changes" >&2
+  echo "  patch|minor|major        Bump the current version by that increment (stable only)" >&2
+  echo "  X.Y.Z[-prerelease]       Use this exact version" >&2
+  echo "  --dry-run                Print every step; make no changes" >&2
   exit 1
 }
 
@@ -84,38 +84,81 @@ fi
 
 CURRENT_VERSION=$(node -p "require('./package.json').version")
 
-[[ "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-  || die "package.json version '${CURRENT_VERSION}' is not a clean X.Y.Z — prerelease versions are not supported"
+SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z-]*(\.[0-9A-Za-z][0-9A-Za-z-]*)*)?$'
+[[ "$CURRENT_VERSION" =~ $SEMVER_RE ]] \
+  || die "package.json version '${CURRENT_VERSION}' is not a valid SemVer version (X.Y.Z or X.Y.Z-prerelease)"
 
-IFS='.' read -r VER_MAJOR VER_MINOR VER_PATCH <<< "$CURRENT_VERSION"
+# Extract the stable X.Y.Z base and detect whether we're currently on a pre-release
+CURRENT_BASE="${CURRENT_VERSION%%-*}"
+IS_PRERELEASE=false
+[[ "$CURRENT_VERSION" != "$CURRENT_BASE" ]] && IS_PRERELEASE=true
+
+IFS='.' read -r VER_MAJOR VER_MINOR VER_PATCH <<< "$CURRENT_BASE"
 
 case "$BUMP" in
-  patch)
-    NEW_VERSION="${VER_MAJOR}.${VER_MINOR}.$((VER_PATCH + 1))"
-    ;;
-  minor)
-    NEW_VERSION="${VER_MAJOR}.$((VER_MINOR + 1)).0"
-    ;;
-  major)
-    NEW_VERSION="$((VER_MAJOR + 1)).0.0"
+  patch|minor|major)
+    [[ "$IS_PRERELEASE" == true ]] \
+      && die "'${BUMP}' bump is not defined for pre-release version '${CURRENT_VERSION}' — specify an explicit version (e.g. '${CURRENT_BASE}' to promote to stable, or '${CURRENT_BASE}-alpha.2' for the next pre-release)"
+    case "$BUMP" in
+      patch) NEW_VERSION="${VER_MAJOR}.${VER_MINOR}.$((VER_PATCH + 1))" ;;
+      minor) NEW_VERSION="${VER_MAJOR}.$((VER_MINOR + 1)).0" ;;
+      major) NEW_VERSION="$((VER_MAJOR + 1)).0.0" ;;
+    esac
     ;;
   *)
-    [[ "$BUMP" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-      || die "invalid argument '${BUMP}' — must be patch/minor/major or X.Y.Z"
+    [[ "$BUMP" =~ $SEMVER_RE ]] \
+      || die "invalid argument '${BUMP}' — must be patch/minor/major or X.Y.Z[-prerelease]"
     NEW_VERSION="$BUMP"
     ;;
 esac
 
-# Guard: new version must be strictly greater than current
-IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<< "$NEW_VERSION"
-if (( NEW_MAJOR < VER_MAJOR ||
-      ( NEW_MAJOR == VER_MAJOR && NEW_MINOR < VER_MINOR ) ||
-      ( NEW_MAJOR == VER_MAJOR && NEW_MINOR == VER_MINOR && NEW_PATCH <= VER_PATCH ) )); then
-  die "version '${NEW_VERSION}' must be strictly greater than current '${CURRENT_VERSION}'"
-fi
+# Guard: new version must be strictly greater than current (SemVer-aware).
+# Bash arithmetic can't handle pre-release suffixes; use Node for the comparison.
+export NEW_VERSION CURRENT_VERSION
+node << 'JSEOF'
+function parse(v) {
+  const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
+  if (!m) { process.stderr.write('error: invalid version: ' + v + '\n'); process.exit(2); }
+  return { major: +m[1], minor: +m[2], patch: +m[3], pre: m[4] ?? null };
+}
+// Compare two dot-separated pre-release identifiers per SemVer §11.4
+function comparePre(a, b) {
+  const ap = a.split('.'), bp = b.split('.');
+  const len = Math.max(ap.length, bp.length);
+  for (let i = 0; i < len; i++) {
+    if (i >= ap.length) return -1; // fewer identifiers = lower precedence
+    if (i >= bp.length) return 1;
+    const ai = ap[i], bi = bp[i];
+    const an = /^\d+$/.test(ai), bn = /^\d+$/.test(bi);
+    if (an && bn) { const d = +ai - +bi; if (d !== 0) return d; }
+    else if (an !== bn) { return an ? -1 : 1; } // numeric < alphanumeric
+    else { if (ai < bi) return -1; if (ai > bi) return 1; }
+  }
+  return 0;
+}
+function cmp(a, b) {
+  const pa = parse(a), pb = parse(b);
+  if (pa.major !== pb.major) return pa.major - pb.major;
+  if (pa.minor !== pb.minor) return pa.minor - pb.minor;
+  if (pa.patch !== pb.patch) return pa.patch - pb.patch;
+  if (pa.pre === null && pb.pre === null) return 0;
+  if (pa.pre === null) return 1;   // release > pre-release of same X.Y.Z
+  if (pb.pre === null) return -1;  // pre-release < release of same X.Y.Z
+  return comparePre(pa.pre, pb.pre);
+}
+const nv = process.env.NEW_VERSION, cv = process.env.CURRENT_VERSION;
+if (cmp(nv, cv) <= 0) {
+  process.stderr.write("error: version '" + nv + "' must be strictly greater than current '" + cv + "'\n");
+  process.exit(1);
+}
+JSEOF
 
 TAG="v${NEW_VERSION}"
 RELEASE_DATE=$(date -u +%Y-%m-%d)
+
+# Detect whether the new version is a pre-release
+IS_NEW_PRERELEASE=false
+[[ "${NEW_VERSION}" == *-* ]] && IS_NEW_PRERELEASE=true
 
 echo "current: ${CURRENT_VERSION}"
 echo "    new: ${NEW_VERSION}  (${TAG})"
@@ -147,8 +190,10 @@ if (out === src) {
   process.exit(1);
 }
 
-// Update Keep-a-Changelog reference links at the bottom
-const linkMatch = out.match(/^\[Unreleased\]:\s*(\S+?)\/compare\/v(\d+\.\d+\.\d+)\.\.\.HEAD\s*$/m);
+// Update Keep-a-Changelog reference links at the bottom.
+// The previous version may itself be a pre-release (e.g. v0.8.0-alpha.1),
+// so match any non-whitespace chars after /compare/v rather than only X.Y.Z.
+const linkMatch = out.match(/^\[Unreleased\]:\s*(\S+?)\/compare\/v(\S+?)\.\.\.HEAD\s*$/m);
 if (linkMatch) {
   const [fullMatch, repoUrl, prevVersion] = linkMatch;
   out = out.replace(
@@ -175,10 +220,17 @@ run git push origin main "$TAG"
 # ── Create GitHub Release ─────────────────────────────────────────────────────
 
 # If this step fails, the tag is already pushed. Retry with:
-#   gh release create "$TAG" --title "$TAG" --generate-notes
-run gh release create "$TAG" \
-  --title "$TAG" \
-  --generate-notes
+#   gh release create "$TAG" --title "$TAG" --generate-notes [--prerelease]
+if [[ "$IS_NEW_PRERELEASE" == true ]]; then
+  run gh release create "$TAG" \
+    --title "$TAG" \
+    --generate-notes \
+    --prerelease
+else
+  run gh release create "$TAG" \
+    --title "$TAG" \
+    --generate-notes
+fi
 
 echo
 echo "Done. ${TAG} is live — publish.yml will handle npm publishing."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -58,8 +58,9 @@ validate_semver() {
     || die "${ctx} '${v}' is not a valid SemVer version (X.Y.Z or X.Y.Z-prerelease)"
   if [[ "$v" == *-* ]]; then
     local pre="${v#*-}" id
-    IFS='.' read -ra _ids <<< "$pre"
-    for id in "${_ids[@]}"; do
+    local -a ids
+    IFS='.' read -ra ids <<< "$pre"
+    for id in "${ids[@]}"; do
       [[ "$id" =~ ^0[0-9]+$ ]] \
         && die "invalid pre-release identifier '${id}' in '${ctx}' '${v}' — numeric identifiers must not have leading zeros"
     done


### PR DESCRIPTION
## What

Extends `scripts/release.sh` to accept SemVer pre-release versions (e.g. `0.8.0-alpha.2`, `0.8.0-beta.1`, `0.8.0-rc.1`) for both the current `package.json` version and the explicit version argument.

## Why

The script previously rejected any package.json version that wasn't a clean `X.Y.Z`, and only accepted `X.Y.Z` as an explicit argument. With the repo currently at `0.8.0-alpha.1`, the alpha tag had to be cut manually — bypassing the script's CHANGELOG promotion, version-monotonicity guard, and preflight checks. Every subsequent pre-release cut (`-alpha.2`, `-beta.1`, `-rc.1`, stable `0.8.0`) would repeat that workaround. Fixes #128.

## Changes

**Precondition regex** — `SEMVER_RE` now accepts `X.Y.Z-prerelease` in addition to `X.Y.Z`. The regex is stricter than the old one: each dot-separated identifier must start with an alphanumeric character, preventing trailing dots and empty identifiers (e.g. `0.8.0-alpha.` is now rejected).

**Bump keywords blocked from pre-release** — `patch`, `minor`, and `major` are undefined when the current version is a pre-release. The script dies with a clear message and hints at the correct form (e.g. `'0.8.0' to promote to stable, or '0.8.0-alpha.2' for the next pre-release`).

**SemVer-aware monotonicity guard** — Replaced the bash arithmetic comparison with an inline Node script that implements SemVer §11.4 pre-release precedence: numeric identifiers compare as integers, numeric < alphanumeric, fewer identifiers = lower precedence, and a pre-release has lower precedence than the same `X.Y.Z` release.

**`--prerelease` flag** — `gh release create` receives `--prerelease` when the new tag has a pre-release suffix. Follows the same detection used in the sibling `agent-receipts/ar` repo.

**CHANGELOG compare-link regex** — Broadened from `\d+\.\d+\.\d+` to `\S+` so the link is correctly rewritten when the previous release was itself a pre-release (e.g. `v0.8.0-alpha.1...HEAD` → `v0.8.0-alpha.2...HEAD`).

## Checklist

- [ ] `pnpm test` passes
- [ ] `pnpm run typecheck` passes
- [x] No real keys or secrets in the diff
- [x] Taxonomy changes include tests in `src/classify.test.ts` — N/A (script-only change)
- [x] AGENTS.md updated (if project structure changed) — N/A