### PR TITLE
fix(daemon): correct Linux socket path fallback and warn on unreachable socket

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -210,6 +210,17 @@ describe("_resolveSocketPath", () => {
     expect(path).toBe("/run/agentreceipts/events.sock");
   });
 
+  it("linux: system fallback when running as root (uid === 0)", () => {
+    // systemd does not create /run/user/0; root uses the system-level socket.
+    const path = _resolveSocketPath({}, "linux", 0);
+    expect(path).toBe("/run/agentreceipts/events.sock");
+  });
+
+  it("linux: empty XDG_RUNTIME_DIR is treated as unset (falls through to uid path)", () => {
+    const path = _resolveSocketPath({ XDG_RUNTIME_DIR: "" }, "linux", 1000);
+    expect(path).toBe("/run/user/1000/agentreceipts/events.sock");
+  });
+
   it("darwin: uses TMPDIR env var", () => {
     const path = _resolveSocketPath({ TMPDIR: "/private/tmp/com.apple.123" }, "darwin", undefined);
     expect(path).toBe("/private/tmp/com.apple.123/agentreceipts/events.sock");

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -14,7 +14,7 @@ import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { createServer, type Server } from "node:net";
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
-import { DIAL_TIMEOUT_MS, Emitter, defaultSocketPath, MAX_FRAME_SIZE } from "./emitter.js";
+import { DIAL_TIMEOUT_MS, Emitter, defaultSocketPath, _resolveSocketPath, MAX_FRAME_SIZE } from "./emitter.js";
 
 // macOS AF_UNIX sun_path is capped at 104 bytes. Node's os.tmpdir() on
 // macOS returns "/var/folders/.../T/" which can push our test socket paths
@@ -165,6 +165,64 @@ describe("defaultSocketPath", () => {
       expect(p.length).toBeGreaterThan(0);
       expect(p).toContain("agentreceipts");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _resolveSocketPath — pure path resolver (platform-independent tests)
+// ---------------------------------------------------------------------------
+
+describe("_resolveSocketPath", () => {
+  it("AGENTRECEIPTS_SOCKET takes precedence over everything", () => {
+    const path = _resolveSocketPath(
+      { AGENTRECEIPTS_SOCKET: "/custom/events.sock" },
+      "linux",
+      1000,
+    );
+    expect(path).toBe("/custom/events.sock");
+  });
+
+  it("AGENTRECEIPTS_SOCKET takes precedence on darwin too", () => {
+    const path = _resolveSocketPath(
+      { AGENTRECEIPTS_SOCKET: "/custom/events.sock", TMPDIR: "/var/folders/abc" },
+      "darwin",
+      undefined,
+    );
+    expect(path).toBe("/custom/events.sock");
+  });
+
+  it("linux: XDG_RUNTIME_DIR is used when set", () => {
+    const path = _resolveSocketPath(
+      { XDG_RUNTIME_DIR: "/run/user/1234" },
+      "linux",
+      1234,
+    );
+    expect(path).toBe("/run/user/1234/agentreceipts/events.sock");
+  });
+
+  it("linux: uid-based path is used when XDG_RUNTIME_DIR is absent", () => {
+    const path = _resolveSocketPath({}, "linux", 1000);
+    expect(path).toBe("/run/user/1000/agentreceipts/events.sock");
+  });
+
+  it("linux: system fallback when XDG_RUNTIME_DIR absent and uid unavailable", () => {
+    const path = _resolveSocketPath({}, "linux", undefined);
+    expect(path).toBe("/run/agentreceipts/events.sock");
+  });
+
+  it("darwin: uses TMPDIR env var", () => {
+    const path = _resolveSocketPath({ TMPDIR: "/private/tmp/com.apple.123" }, "darwin", undefined);
+    expect(path).toBe("/private/tmp/com.apple.123/agentreceipts/events.sock");
+  });
+
+  it("darwin: falls back to /tmp when TMPDIR is unset", () => {
+    const path = _resolveSocketPath({}, "darwin", undefined);
+    expect(path).toBe("/tmp/agentreceipts/events.sock");
+  });
+
+  it("unknown platform: returns empty string", () => {
+    const path = _resolveSocketPath({}, "win32", undefined);
+    expect(path).toBe("");
   });
 });
 

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -119,32 +119,34 @@ interface WireFrame {
  * 1. AGENTRECEIPTS_SOCKET environment variable (any platform).
  * 2. macOS: $TMPDIR/agentreceipts/events.sock (TMPDIR defaults to /tmp).
  * 3. Linux with $XDG_RUNTIME_DIR set: $XDG_RUNTIME_DIR/agentreceipts/events.sock.
- * 4. Linux with process uid: /run/user/<uid>/agentreceipts/events.sock.
+ * 4. Linux, non-root uid: /run/user/<uid>/agentreceipts/events.sock.
+ *    (systemd does not create /run/user/0 for root; fall through to system path.)
  * 5. Linux system fallback: /run/agentreceipts/events.sock.
  * 6. Other platforms: empty string — pass socketPath explicitly.
  *
- * @internal
+ * @internal Exported for testing; use defaultSocketPath() in production code.
  */
 export function _resolveSocketPath(
   env: Readonly<Record<string, string | undefined>>,
-  os: string,
+  platformName: string,
   uid: number | undefined,
 ): string {
   const envPath = env["AGENTRECEIPTS_SOCKET"];
   if (envPath) {
     return envPath;
   }
-  if (os === "darwin") {
+  if (platformName === "darwin") {
     const tmpdir = env["TMPDIR"] ?? "/tmp";
     return join(tmpdir, "agentreceipts", "events.sock");
   }
-  if (os === "linux") {
+  if (platformName === "linux") {
     const xdgRuntime = env["XDG_RUNTIME_DIR"];
     if (xdgRuntime) {
       return join(xdgRuntime, "agentreceipts", "events.sock");
     }
-    if (uid !== undefined) {
-      return `/run/user/${uid}/agentreceipts/events.sock`;
+    // systemd creates /run/user/<uid> only for non-root users; root falls through.
+    if (uid !== undefined && uid !== 0) {
+      return join("/run/user", String(uid), "agentreceipts", "events.sock");
     }
     return "/run/agentreceipts/events.sock";
   }
@@ -153,14 +155,7 @@ export function _resolveSocketPath(
 
 /**
  * Returns the per-OS default path for the daemon socket.
- *
- * Resolution order:
- * 1. AGENTRECEIPTS_SOCKET environment variable (any platform).
- * 2. macOS: $TMPDIR/agentreceipts/events.sock (TMPDIR defaults to /tmp).
- * 3. Linux with $XDG_RUNTIME_DIR set: $XDG_RUNTIME_DIR/agentreceipts/events.sock.
- * 4. Linux with process uid: /run/user/<uid>/agentreceipts/events.sock.
- * 5. Linux system fallback: /run/agentreceipts/events.sock.
- * 6. Other platforms: empty string — pass socketPath explicitly.
+ * See _resolveSocketPath for the full resolution order.
  */
 export function defaultSocketPath(): string {
   return _resolveSocketPath(process.env, platform(), process.getuid?.());

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -112,33 +112,58 @@ interface WireFrame {
 }
 
 /**
+ * Pure socket path resolver, extracted for deterministic testing without
+ * platform mocks. Call defaultSocketPath() for normal use.
+ *
+ * Resolution order:
+ * 1. AGENTRECEIPTS_SOCKET environment variable (any platform).
+ * 2. macOS: $TMPDIR/agentreceipts/events.sock (TMPDIR defaults to /tmp).
+ * 3. Linux with $XDG_RUNTIME_DIR set: $XDG_RUNTIME_DIR/agentreceipts/events.sock.
+ * 4. Linux with process uid: /run/user/<uid>/agentreceipts/events.sock.
+ * 5. Linux system fallback: /run/agentreceipts/events.sock.
+ * 6. Other platforms: empty string — pass socketPath explicitly.
+ *
+ * @internal
+ */
+export function _resolveSocketPath(
+  env: Readonly<Record<string, string | undefined>>,
+  os: string,
+  uid: number | undefined,
+): string {
+  const envPath = env["AGENTRECEIPTS_SOCKET"];
+  if (envPath) {
+    return envPath;
+  }
+  if (os === "darwin") {
+    const tmpdir = env["TMPDIR"] ?? "/tmp";
+    return join(tmpdir, "agentreceipts", "events.sock");
+  }
+  if (os === "linux") {
+    const xdgRuntime = env["XDG_RUNTIME_DIR"];
+    if (xdgRuntime) {
+      return join(xdgRuntime, "agentreceipts", "events.sock");
+    }
+    if (uid !== undefined) {
+      return `/run/user/${uid}/agentreceipts/events.sock`;
+    }
+    return "/run/agentreceipts/events.sock";
+  }
+  return "";
+}
+
+/**
  * Returns the per-OS default path for the daemon socket.
  *
  * Resolution order:
  * 1. AGENTRECEIPTS_SOCKET environment variable (any platform).
  * 2. macOS: $TMPDIR/agentreceipts/events.sock (TMPDIR defaults to /tmp).
  * 3. Linux with $XDG_RUNTIME_DIR set: $XDG_RUNTIME_DIR/agentreceipts/events.sock.
- * 4. Linux fallback: /run/agentreceipts/events.sock.
- * 5. Other platforms: empty string — pass socketPath explicitly.
+ * 4. Linux with process uid: /run/user/<uid>/agentreceipts/events.sock.
+ * 5. Linux system fallback: /run/agentreceipts/events.sock.
+ * 6. Other platforms: empty string — pass socketPath explicitly.
  */
 export function defaultSocketPath(): string {
-  const envPath = process.env.AGENTRECEIPTS_SOCKET;
-  if (envPath) {
-    return envPath;
-  }
-  const os = platform();
-  if (os === "darwin") {
-    const tmpdir = process.env.TMPDIR ?? "/tmp";
-    return join(tmpdir, "agentreceipts", "events.sock");
-  }
-  if (os === "linux") {
-    const xdgRuntime = process.env.XDG_RUNTIME_DIR;
-    if (xdgRuntime) {
-      return join(xdgRuntime, "agentreceipts", "events.sock");
-    }
-    return "/run/agentreceipts/events.sock";
-  }
-  return "";
+  return _resolveSocketPath(process.env, platform(), process.getuid?.());
 }
 
 /**

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -128,7 +128,7 @@ interface WireFrame {
  */
 export function _resolveSocketPath(
   env: Readonly<Record<string, string | undefined>>,
-  platformName: string,
+  platformName: NodeJS.Platform,
   uid: number | undefined,
 ): string {
   const envPath = env["AGENTRECEIPTS_SOCKET"];

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,19 +94,33 @@ export default definePluginEntry({
           // check and the constructor call (the logged path must match the
           // one actually used).
           emitter = new Emitter({ socketPath });
+
+          // Probe the socket file before declaring readiness. The emitter
+          // dials lazily so construction always succeeds — a missing socket
+          // would only surface as a silent drop on the first emit(). A
+          // synchronous stat here catches the "daemon not installed" case
+          // at startup and gives the operator an actionable warning.
+          try {
+            statSync(socketPath);
+          } catch (err) {
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code === "ENOENT") {
+              api.logger.warn(
+                `agent-receipts: daemon forwarding enabled but no socket file at ${socketPath}`,
+              );
+              api.logger.warn(
+                "=> Install and start the daemon: https://github.com/agent-receipts/ar/tree/main/daemon",
+              );
+            } else {
+              api.logger.warn(
+                `agent-receipts: daemon forwarding enabled but socket probe failed at ${socketPath}: ${String(err)}`,
+              );
+            }
+          }
+
           api.logger.info(
             `agent-receipts: daemon emitter ready (socket=${socketPath}, session_id=${emitter.sessionId})`,
           );
-          try {
-            statSync(socketPath);
-          } catch {
-            api.logger.warn(
-              `agent-receipts: daemon forwarding enabled but socket unreachable at ${socketPath}`,
-            );
-            api.logger.warn(
-              "→ Install and start the daemon: https://github.com/agent-receipts/ar/tree/main/daemon",
-            );
-          }
         } catch (err) {
           api.logger.warn(`agent-receipts: daemon emitter unavailable: ${String(err)}`);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
  */
 
 import { dirname } from "node:path";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, statSync } from "node:fs";
 import { definePluginEntry } from "./openclaw-types.js";
 import { openStore } from "@agnt-rcpt/sdk-ts";
 
@@ -97,6 +97,16 @@ export default definePluginEntry({
           api.logger.info(
             `agent-receipts: daemon emitter ready (socket=${socketPath}, session_id=${emitter.sessionId})`,
           );
+          try {
+            statSync(socketPath);
+          } catch {
+            api.logger.warn(
+              `agent-receipts: daemon forwarding enabled but socket unreachable at ${socketPath}`,
+            );
+            api.logger.warn(
+              "→ Install and start the daemon: https://github.com/agent-receipts/ar/tree/main/daemon",
+            );
+          }
         } catch (err) {
           api.logger.warn(`agent-receipts: daemon emitter unavailable: ${String(err)}`);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,13 +95,24 @@ export default definePluginEntry({
           // one actually used).
           emitter = new Emitter({ socketPath });
 
-          // The emitter dials lazily, so a missing socket only surfaces as a
-          // silent per-emit drop. A startup stat gives the operator an early warning.
+          // The emitter dials lazily, so a missing or non-socket path only
+          // surfaces as a silent per-emit drop. A startup stat gives the
+          // operator an early warning.
           try {
-            statSync(socketPath);
+            const stats = statSync(socketPath);
+            if (!stats.isSocket()) {
+              api.logger.warn(
+                `agent-receipts: daemon forwarding enabled but path is not a Unix socket: ${socketPath}`,
+              );
+            }
           } catch (err) {
-            const e = err as NodeJS.ErrnoException;
-            if (e.code === "ENOENT") {
+            // Narrow structurally; avoid asserting the full ErrnoException shape.
+            const code =
+              err !== null && typeof err === "object" && "code" in err
+                ? (err as { code?: string }).code
+                : undefined;
+            const message = err instanceof Error ? err.message : String(err);
+            if (code === "ENOENT") {
               api.logger.warn(
                 `agent-receipts: daemon forwarding enabled but no socket file at ${socketPath}`,
               );
@@ -110,7 +121,7 @@ export default definePluginEntry({
               );
             } else {
               api.logger.warn(
-                `agent-receipts: daemon forwarding enabled but socket probe failed at ${socketPath}: ${e.message} (${e.code ?? "unknown"})`,
+                `agent-receipts: daemon forwarding enabled but socket probe failed at ${socketPath}: ${message} (${code ?? "unknown"})`,
               );
             }
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,9 @@
  * audit trail using the Agent Receipts TypeScript SDK.
  */
 
+import { createConnection } from "node:net";
 import { dirname } from "node:path";
-import { mkdirSync, statSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { definePluginEntry } from "./openclaw-types.js";
 import { openStore } from "@agnt-rcpt/sdk-ts";
 
@@ -20,7 +21,7 @@ import {
   type HookDeps,
   type PendingMap,
 } from "./hooks.js";
-import { Emitter, defaultSocketPath } from "./emitter.js";
+import { Emitter, defaultSocketPath, DIAL_TIMEOUT_MS } from "./emitter.js";
 import { resetChain, getChainId, type ChainsMap, type ChainState } from "./chain.js";
 import { createQueryReceiptsToolFactory, createVerifyChainToolFactory } from "./tools.js";
 
@@ -95,36 +96,44 @@ export default definePluginEntry({
           // one actually used).
           emitter = new Emitter({ socketPath });
 
-          // The emitter dials lazily, so a missing or non-socket path only
-          // surfaces as a silent per-emit drop. A startup stat gives the
-          // operator an early warning.
-          try {
-            const stats = statSync(socketPath);
-            if (!stats.isSocket()) {
+          // The emitter dials lazily, so an unreachable socket (missing file,
+          // stale socket, daemon not listening) only surfaces as a silent
+          // per-emit drop. Probe once at startup so operators get an early
+          // actionable warning instead.
+          void new Promise<void>((resolve) => {
+            let settled = false;
+            const settle = (): void => {
+              if (settled) return;
+              settled = true;
+              resolve();
+            };
+            const probe = createConnection({ path: socketPath });
+            const timer = setTimeout(() => {
+              probe.destroy();
               api.logger.warn(
-                `agent-receipts: daemon forwarding enabled but path is not a Unix socket: ${socketPath}`,
-              );
-            }
-          } catch (err) {
-            // Narrow structurally; avoid asserting the full ErrnoException shape.
-            const code =
-              err !== null && typeof err === "object" && "code" in err
-                ? (err as { code?: string }).code
-                : undefined;
-            const message = err instanceof Error ? err.message : String(err);
-            if (code === "ENOENT") {
-              api.logger.warn(
-                `agent-receipts: daemon forwarding enabled but no socket file at ${socketPath}`,
+                `agent-receipts: daemon forwarding enabled but socket unreachable at ${socketPath} (connection timed out)`,
               );
               api.logger.warn(
                 "=> Install and start the daemon: https://github.com/agent-receipts/ar/tree/main/daemon",
               );
-            } else {
+              settle();
+            }, DIAL_TIMEOUT_MS);
+            probe.once("connect", () => {
+              clearTimeout(timer);
+              probe.destroy();
+              settle();
+            });
+            probe.once("error", (err) => {
+              clearTimeout(timer);
               api.logger.warn(
-                `agent-receipts: daemon forwarding enabled but socket probe failed at ${socketPath}: ${message} (${code ?? "unknown"})`,
+                `agent-receipts: daemon forwarding enabled but socket unreachable at ${socketPath}: ${err.message}`,
               );
-            }
-          }
+              api.logger.warn(
+                "=> Install and start the daemon: https://github.com/agent-receipts/ar/tree/main/daemon",
+              );
+              settle();
+            });
+          });
 
           api.logger.info(
             `agent-receipts: daemon emitter ready (socket=${socketPath}, session_id=${emitter.sessionId})`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,16 +95,13 @@ export default definePluginEntry({
           // one actually used).
           emitter = new Emitter({ socketPath });
 
-          // Probe the socket file before declaring readiness. The emitter
-          // dials lazily so construction always succeeds — a missing socket
-          // would only surface as a silent drop on the first emit(). A
-          // synchronous stat here catches the "daemon not installed" case
-          // at startup and gives the operator an actionable warning.
+          // The emitter dials lazily, so a missing socket only surfaces as a
+          // silent per-emit drop. A startup stat gives the operator an early warning.
           try {
             statSync(socketPath);
           } catch (err) {
-            const code = (err as NodeJS.ErrnoException).code;
-            if (code === "ENOENT") {
+            const e = err as NodeJS.ErrnoException;
+            if (e.code === "ENOENT") {
               api.logger.warn(
                 `agent-receipts: daemon forwarding enabled but no socket file at ${socketPath}`,
               );
@@ -113,7 +110,7 @@ export default definePluginEntry({
               );
             } else {
               api.logger.warn(
-                `agent-receipts: daemon forwarding enabled but socket probe failed at ${socketPath}: ${String(err)}`,
+                `agent-receipts: daemon forwarding enabled but socket probe failed at ${socketPath}: ${e.message} (${e.code ?? "unknown"})`,
               );
             }
           }

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -259,7 +259,7 @@ describe("integration: full plugin lifecycle", () => {
     expect(logs.some((l) => l.includes("plugin disabled"))).toBe(true);
   });
 
-  it("daemonForwarding: logs warning when socket file is absent", () => {
+  it("daemonForwarding: logs warning when socket is unreachable", async () => {
     // Use AGENTRECEIPTS_SOCKET to pin the socket path to a guaranteed-absent location.
     const missingSocket = join(tmpdir(), `ar-absent-${randomUUID()}.sock`);
     const saved = process.env.AGENTRECEIPTS_SOCKET;
@@ -267,33 +267,15 @@ describe("integration: full plugin lifecycle", () => {
     try {
       const { logs } = setupPlugin({ daemonForwarding: true });
 
+      // The connection probe is fire-and-forget; wait for it to settle.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
       const warnLogs = logs.filter((l) => l.startsWith("WARN:"));
-      expect(warnLogs.some((l) => l.includes("no socket file at") && l.includes(missingSocket))).toBe(true);
+      expect(warnLogs.some((l) => l.includes("socket unreachable") && l.includes(missingSocket))).toBe(true);
       expect(warnLogs.some((l) => l.includes("Install and start the daemon"))).toBe(true);
       // The emitter is still constructed (fire-and-forget) so "ready" is also logged.
       expect(logs.some((l) => l.includes("daemon emitter ready"))).toBe(true);
     } finally {
-      if (saved === undefined) {
-        delete process.env.AGENTRECEIPTS_SOCKET;
-      } else {
-        process.env.AGENTRECEIPTS_SOCKET = saved;
-      }
-    }
-  });
-
-  it("daemonForwarding: logs warning when path exists but is not a Unix socket", () => {
-    // Create a regular file at the socket path to trigger the isSocket() check.
-    const notASocket = join(tmpdir(), `ar-notasock-${randomUUID()}`);
-    writeFileSync(notASocket, "");
-    const saved = process.env.AGENTRECEIPTS_SOCKET;
-    process.env.AGENTRECEIPTS_SOCKET = notASocket;
-    try {
-      const { logs } = setupPlugin({ daemonForwarding: true });
-
-      const warnLogs = logs.filter((l) => l.startsWith("WARN:"));
-      expect(warnLogs.some((l) => l.includes("not a Unix socket") && l.includes(notASocket))).toBe(true);
-    } finally {
-      rmSync(notASocket, { force: true });
       if (saved === undefined) {
         delete process.env.AGENTRECEIPTS_SOCKET;
       } else {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -259,6 +259,28 @@ describe("integration: full plugin lifecycle", () => {
     expect(logs.some((l) => l.includes("plugin disabled"))).toBe(true);
   });
 
+  it("daemonForwarding: logs warning when socket file is absent", () => {
+    // Use AGENTRECEIPTS_SOCKET to pin the socket path to a guaranteed-absent location.
+    const missingSocket = join(tmpdir(), `ar-absent-${randomUUID()}.sock`);
+    const saved = process.env.AGENTRECEIPTS_SOCKET;
+    process.env.AGENTRECEIPTS_SOCKET = missingSocket;
+    try {
+      const { logs } = setupPlugin({ daemonForwarding: true });
+
+      const warnLogs = logs.filter((l) => l.startsWith("WARN:"));
+      expect(warnLogs.some((l) => l.includes("no socket file at") && l.includes(missingSocket))).toBe(true);
+      expect(warnLogs.some((l) => l.includes("Install and start the daemon"))).toBe(true);
+      // The emitter is still constructed (fire-and-forget) so "ready" is also logged.
+      expect(logs.some((l) => l.includes("daemon emitter ready"))).toBe(true);
+    } finally {
+      if (saved === undefined) {
+        delete process.env.AGENTRECEIPTS_SOCKET;
+      } else {
+        process.env.AGENTRECEIPTS_SOCKET = saved;
+      }
+    }
+  });
+
   it("tool call failure records failure outcome", async () => {
     const { hooks, tools } = setupPlugin();
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -273,6 +273,27 @@ describe("integration: full plugin lifecycle", () => {
       // The emitter is still constructed (fire-and-forget) so "ready" is also logged.
       expect(logs.some((l) => l.includes("daemon emitter ready"))).toBe(true);
     } finally {
+      if (saved === undefined) {
+        delete process.env.AGENTRECEIPTS_SOCKET;
+      } else {
+        process.env.AGENTRECEIPTS_SOCKET = saved;
+      }
+    }
+  });
+
+  it("daemonForwarding: logs warning when path exists but is not a Unix socket", () => {
+    // Create a regular file at the socket path to trigger the isSocket() check.
+    const notASocket = join(tmpdir(), `ar-notasock-${randomUUID()}`);
+    writeFileSync(notASocket, "");
+    const saved = process.env.AGENTRECEIPTS_SOCKET;
+    process.env.AGENTRECEIPTS_SOCKET = notASocket;
+    try {
+      const { logs } = setupPlugin({ daemonForwarding: true });
+
+      const warnLogs = logs.filter((l) => l.startsWith("WARN:"));
+      expect(warnLogs.some((l) => l.includes("not a Unix socket") && l.includes(notASocket))).toBe(true);
+    } finally {
+      rmSync(notASocket, { force: true });
       if (saved === undefined) {
         delete process.env.AGENTRECEIPTS_SOCKET;
       } else {


### PR DESCRIPTION
## Summary

Fixes #133. Two bugs in daemon forwarding socket resolution:

- **Bug 1 — Wrong path fallback:** when `XDG_RUNTIME_DIR` is unset (common when openclaw runs as a system service with `User=<name>`), the plugin was falling back directly to `/run/agentreceipts/events.sock` (the system-daemon path). For user-level daemon installs the correct path is `/run/user/<uid>/agentreceipts/events.sock`, derived from `process.getuid()`. The system path is now a last resort, only reached when `getuid()` is unavailable (e.g. Windows).

- **Bug 2 — Silent failure:** when the resolved socket was unreachable at startup, the plugin logged nothing, so users saw 0 receipts with no explanation. After creating the emitter, `statSync` now probes the socket path and logs a clear `warn` (not an error — daemon forwarding is fire-and-forget) if the socket file is absent:
  ```
  agent-receipts: daemon forwarding enabled but socket unreachable at <path>
  → Install and start the daemon: https://github.com/agent-receipts/ar/tree/main/daemon
  ```

Also extracts the pure path resolution logic into `_resolveSocketPath(env, os, uid)` so the four resolution cases can be tested deterministically without platform mocks.

## Changes

- `src/emitter.ts` — extract `_resolveSocketPath()`, add uid-based path step, update `defaultSocketPath()` to call it
- `src/index.ts` — add `statSync` startup probe, log warning when socket unreachable
- `src/emitter.test.ts` — add 8 new tests covering all `_resolveSocketPath` branches: `AGENTRECEIPTS_SOCKET` set, `XDG_RUNTIME_DIR` set, neither set (uid path), uid unavailable (system fallback), darwin TMPDIR, darwin fallback, unknown platform

## Test plan

- [ ] `pnpm test` — all 212 tests pass (2 skipped, daemon binary absent)
- [ ] `pnpm run typecheck` — no errors
- [ ] On Linux without `XDG_RUNTIME_DIR` set, plugin now resolves to `/run/user/<uid>/agentreceipts/events.sock` instead of `/run/agentreceipts/events.sock`
- [ ] With `daemonForwarding: true` and no socket present, startup logs show the two-line warning instead of silence