### PR TITLE
chore(release): v0.8.0 CHANGELOG entry and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Startup warning when daemon socket unreachable** ([#133](https://github.com/agent-receipts/openclaw/issues/133)):
-  If `daemonForwarding` is enabled but the resolved socket path is not present
+  If `daemonForwarding` is enabled but the resolved socket path is unreachable
   at startup, the plugin now logs a clear two-line warning with the socket path
   and a link to the daemon setup guide. Previously the mismatch was silent.
 - **Daemon setup documentation** ([#132](https://github.com/agent-receipts/openclaw/issues/132)):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump to `0.8.0` to maintain lockstep with the coordinated
   agent-receipts v0.8.0 release.
-- Bump `@agnt-rcpt/sdk-ts` peer/dependency range to `^0.8.0`.
 
 ## [0.6.0] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-15
+
+### Fixed
+
+- **Socket path fallback on Linux** ([#133](https://github.com/agent-receipts/openclaw/issues/133)):
+  When `XDG_RUNTIME_DIR` is unset (common when the gateway runs as a system
+  service with `User=`), the daemon emitter now resolves the socket path from
+  `process.getuid()` (`/run/user/<uid>/agentreceipts/events.sock`) before
+  falling back to the system-wide path. Previously it fell back directly to
+  `/run/agentreceipts/events.sock`, silently misdirecting frames.
+
+### Added
+
+- **Startup warning when daemon socket unreachable** ([#133](https://github.com/agent-receipts/openclaw/issues/133)):
+  If `daemonForwarding` is enabled but the resolved socket path is not present
+  at startup, the plugin now logs a clear two-line warning with the socket path
+  and a link to the daemon setup guide. Previously the mismatch was silent.
+- **Daemon setup documentation** ([#132](https://github.com/agent-receipts/openclaw/issues/132)):
+  README now includes a "Setting up the daemon" subsection under
+  `daemonForwarding` covering macOS (Homebrew), Linux (install script), and the
+  `XDG_RUNTIME_DIR` system-service gotcha.
+
+### Changed
+
+- Version bump to `0.8.0` to maintain lockstep with the coordinated
+  agent-receipts v0.8.0 release.
+- Bump `@agnt-rcpt/sdk-ts` peer/dependency range to `^0.8.0`.
+
 ## [0.6.0] - 2026-05-02
 
 ### Changed (breaking)
@@ -157,7 +185,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security hardening: key file permissions, input validation, pending-map memory
   leak prevention (#22).
 
-[Unreleased]: https://github.com/agent-receipts/openclaw/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/agent-receipts/openclaw/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/agent-receipts/openclaw/compare/v0.6.0...v0.8.0
 [0.6.0]: https://github.com/agent-receipts/openclaw/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/agent-receipts/openclaw/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/agent-receipts/openclaw/compare/v0.3.3...v0.4.0

--- a/package.json
+++ b/package.json
@@ -1,62 +1,62 @@
 {
-	"name": "@agnt-rcpt/openclaw",
-	"version": "0.8.0",
-	"description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
-	"type": "module",
-	"license": "MIT",
-	"author": "Otto Jongerius",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/agent-receipts/openclaw.git"
-	},
-	"keywords": [
-		"openclaw",
-		"agent-receipts",
-		"audit-trail",
-		"receipts",
-		"verifiable-credentials",
-		"ed25519"
-	],
-	"exports": {
-		".": {
-			"types": "./dist/src/index.d.ts",
-			"default": "./dist/src/index.js"
-		}
-	},
-	"bin": {
-		"openclaw-agent-receipts": "dist/src/cli.js"
-	},
-	"files": [
-		"dist",
-		"taxonomy.json",
-		"openclaw.plugin.json"
-	],
-	"engines": {
-		"node": ">=22.11.0"
-	},
-	"scripts": {
-		"build": "tsc -p tsconfig.build.json",
-		"test": "vitest run",
-		"test:coverage": "vitest run --coverage",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@agnt-rcpt/sdk-ts": "^0.6.0",
-		"@sinclair/typebox": "0.34.49"
-	},
-	"devDependencies": {
-		"@types/node": "^25.5.0",
-		"@vitest/coverage-v8": "^4.1.2",
-		"openclaw": "*",
-		"typescript": "^6.0.2",
-		"vitest": "^4.1.4"
-	},
-	"peerDependencies": {
-		"openclaw": ">=2025.0.0"
-	},
-	"openclaw": {
-		"extensions": [
-			"./dist/src/index.js"
-		]
-	}
+  "name": "@agnt-rcpt/openclaw",
+  "version": "0.8.0",
+  "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
+  "type": "module",
+  "license": "MIT",
+  "author": "Otto Jongerius",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/agent-receipts/openclaw.git"
+  },
+  "keywords": [
+    "openclaw",
+    "agent-receipts",
+    "audit-trail",
+    "receipts",
+    "verifiable-credentials",
+    "ed25519"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    }
+  },
+  "bin": {
+    "openclaw-agent-receipts": "dist/src/cli.js"
+  },
+  "files": [
+    "dist",
+    "taxonomy.json",
+    "openclaw.plugin.json"
+  ],
+  "engines": {
+    "node": ">=22.11.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@agnt-rcpt/sdk-ts": "^0.6.0",
+    "@sinclair/typebox": "0.34.49"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "@vitest/coverage-v8": "^4.1.2",
+    "openclaw": "*",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2025.0.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./dist/src/index.js"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,62 +1,62 @@
 {
-  "name": "@agnt-rcpt/openclaw",
-  "version": "0.8.0-alpha.1",
-  "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
-  "type": "module",
-  "license": "MIT",
-  "author": "Otto Jongerius",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/agent-receipts/openclaw.git"
-  },
-  "keywords": [
-    "openclaw",
-    "agent-receipts",
-    "audit-trail",
-    "receipts",
-    "verifiable-credentials",
-    "ed25519"
-  ],
-  "exports": {
-    ".": {
-      "types": "./dist/src/index.d.ts",
-      "default": "./dist/src/index.js"
-    }
-  },
-  "bin": {
-    "openclaw-agent-receipts": "dist/src/cli.js"
-  },
-  "files": [
-    "dist",
-    "taxonomy.json",
-    "openclaw.plugin.json"
-  ],
-  "engines": {
-    "node": ">=22.11.0"
-  },
-  "scripts": {
-    "build": "tsc -p tsconfig.build.json",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit"
-  },
-  "dependencies": {
-    "@agnt-rcpt/sdk-ts": "^0.6.0",
-    "@sinclair/typebox": "0.34.49"
-  },
-  "devDependencies": {
-    "@types/node": "^25.5.0",
-    "@vitest/coverage-v8": "^4.1.2",
-    "openclaw": "*",
-    "typescript": "^6.0.2",
-    "vitest": "^4.1.4"
-  },
-  "peerDependencies": {
-    "openclaw": ">=2025.0.0"
-  },
-  "openclaw": {
-    "extensions": [
-      "./dist/src/index.js"
-    ]
-  }
+	"name": "@agnt-rcpt/openclaw",
+	"version": "0.8.0",
+	"description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
+	"type": "module",
+	"license": "MIT",
+	"author": "Otto Jongerius",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/agent-receipts/openclaw.git"
+	},
+	"keywords": [
+		"openclaw",
+		"agent-receipts",
+		"audit-trail",
+		"receipts",
+		"verifiable-credentials",
+		"ed25519"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/src/index.d.ts",
+			"default": "./dist/src/index.js"
+		}
+	},
+	"bin": {
+		"openclaw-agent-receipts": "dist/src/cli.js"
+	},
+	"files": [
+		"dist",
+		"taxonomy.json",
+		"openclaw.plugin.json"
+	],
+	"engines": {
+		"node": ">=22.11.0"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.build.json",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@agnt-rcpt/sdk-ts": "^0.8.0",
+		"@sinclair/typebox": "0.34.49"
+	},
+	"devDependencies": {
+		"@types/node": "^25.5.0",
+		"@vitest/coverage-v8": "^4.1.2",
+		"openclaw": "*",
+		"typescript": "^6.0.2",
+		"vitest": "^4.1.4"
+	},
+	"peerDependencies": {
+		"openclaw": ">=2025.0.0"
+	},
+	"openclaw": {
+		"extensions": [
+			"./dist/src/index.js"
+		]
+	}
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@agnt-rcpt/sdk-ts": "^0.8.0",
+		"@agnt-rcpt/sdk-ts": "^0.6.0",
 		"@sinclair/typebox": "0.34.49"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Pre-tagging housekeeping for the coordinated v0.8.0 release.

## Changes

- **CHANGELOG**: add `[0.8.0]` entry covering socket path fix (#133), startup warning (#133), daemon setup docs (#132), and lockstep version bump
- **CHANGELOG links**: update comparison URLs to reflect v0.8.0 as latest
- **package.json**: `0.8.0-alpha.1` → `0.8.0`

Note: `@agnt-rcpt/sdk-ts` dep range stays at `^0.6.0` for now — bumping requires a lockfile update and is tracked as a follow-up.

Part of agent-receipts/ar#367 — coordinated pre-release tags (2a).