### PR TITLE
feat(emitter): track and flush drop_count to daemon (issue #139 stage 1)

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -730,6 +730,134 @@ describe("frame round-trip (in-process server)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// drop_count tracking
+// ---------------------------------------------------------------------------
+
+describe("drop_count tracking", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeShortTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("omits drop_count when there are no prior drops", async () => {
+    const socketPath = join(tmpDir, "events.sock");
+    const { frames, close } = await createEchoServer(socketPath);
+
+    const emitter = new Emitter({ socketPath });
+    await emitter.emit({ tool: { name: "bash" }, decision: "allowed" });
+    await waitFor(() => frames.length >= 1);
+
+    const parsed = JSON.parse(frames[0].toString("utf8")) as Record<string, unknown>;
+    expect(parsed.drop_count).toBeUndefined();
+
+    emitter.close();
+    await close();
+  });
+
+  it("includes drop_count in the next successful frame after transport failures", async () => {
+    const socketPath = join(tmpDir, "drop.sock");
+    const emitter = new Emitter({ socketPath });
+
+    // No server listening — each emit fails and increments dropCount.
+    await emitter.emit({ tool: { name: "tool-1" }, decision: "allowed" });
+    await emitter.emit({ tool: { name: "tool-2" }, decision: "allowed" });
+
+    // Now start the server and send a third emit.
+    const { frames, close } = await createEchoServer(socketPath);
+    await emitter.emit({ tool: { name: "tool-3" }, decision: "allowed" });
+    await waitFor(() => frames.length >= 1);
+
+    const parsed = JSON.parse(frames[0].toString("utf8")) as Record<string, unknown>;
+    expect(parsed.drop_count).toBe(2);
+
+    emitter.close();
+    await close();
+  });
+
+  it("resets drop_count to zero after a successful flush", async () => {
+    const socketPath = join(tmpDir, "reset.sock");
+    const emitter = new Emitter({ socketPath });
+
+    // Cause one drop.
+    await emitter.emit({ tool: { name: "drop-1" }, decision: "allowed" });
+
+    // Start server — next emit flushes the drop count.
+    const { frames, close } = await createEchoServer(socketPath);
+    await emitter.emit({ tool: { name: "flush" }, decision: "allowed" });
+    await waitFor(() => frames.length >= 1);
+
+    const parsed1 = JSON.parse(frames[0].toString("utf8")) as Record<string, unknown>;
+    expect(parsed1.drop_count).toBe(1);
+
+    // Subsequent emit with no new drops must not include drop_count.
+    await emitter.emit({ tool: { name: "clean" }, decision: "allowed" });
+    await waitFor(() => frames.length >= 2);
+
+    const parsed2 = JSON.parse(frames[1].toString("utf8")) as Record<string, unknown>;
+    expect(parsed2.drop_count).toBeUndefined();
+
+    emitter.close();
+    await close();
+  });
+
+  it("accumulates drop_count across multiple failures before a flush", async () => {
+    const socketPath = join(tmpDir, "accum.sock");
+    const emitter = new Emitter({ socketPath });
+
+    // Five drops before any successful send.
+    for (let i = 0; i < 5; i++) {
+      await emitter.emit({ tool: { name: `drop-${i}` }, decision: "allowed" });
+    }
+
+    const { frames, close } = await createEchoServer(socketPath);
+    await emitter.emit({ tool: { name: "flush" }, decision: "allowed" });
+    await waitFor(() => frames.length >= 1);
+
+    const parsed = JSON.parse(frames[0].toString("utf8")) as Record<string, unknown>;
+    expect(parsed.drop_count).toBe(5);
+
+    emitter.close();
+    await close();
+  });
+
+  it("restores drop_count when the oversized-frame guard fires", async () => {
+    // An oversized frame is a caller bug — drop_count must survive so it is
+    // reported in the next frame that fits.
+    const socketPath = join(tmpDir, "oversize.sock");
+    const emitter = new Emitter({ socketPath });
+
+    // Cause one drop.
+    await emitter.emit({ tool: { name: "drop-1" }, decision: "allowed" });
+
+    // Attempt an oversized frame — must fail fast (Error) and not lose dropCount.
+    const bigValue = "x".repeat(MAX_FRAME_SIZE + 1);
+    const oversizeErr = await emitter.emit({
+      tool: { name: "big" },
+      input: JSON.stringify({ data: bigValue }),
+      decision: "allowed",
+    });
+    expect(oversizeErr).toBeInstanceOf(Error);
+    expect(oversizeErr!.message).toMatch(/frame too large/);
+
+    // Now start server — drop_count should still be 1.
+    const { frames, close } = await createEchoServer(socketPath);
+    await emitter.emit({ tool: { name: "flush" }, decision: "allowed" });
+    await waitFor(() => frames.length >= 1);
+
+    const parsed = JSON.parse(frames[0].toString("utf8")) as Record<string, unknown>;
+    expect(parsed.drop_count).toBe(1);
+
+    emitter.close();
+    await close();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Round-trip against the real daemon binary (skipped if binary absent)
 // ---------------------------------------------------------------------------
 

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -933,6 +933,84 @@ describe("drop_count tracking", () => {
     await close();
   });
 
+  it("reports drop_count correctly when an earlier concurrent emit fails and a later one succeeds", async () => {
+    // Regression for the race fixed in this PR: if dropCount is captured in
+    // emit() rather than doWrite(), a later fire-and-forget emit captures
+    // dropCount=0 before the earlier queued write fails. The later frame would
+    // then omit drop_count even though a drop occurred.
+    const socketPath = join(tmpDir, "concurrent-drop.sock");
+
+    // Start a server that accepts exactly one connection, records the first
+    // frame, then destroys the connection so the emitter must redial.
+    const frames: Buffer[] = [];
+    const s1 = createServer((socket) => {
+      let buf = Buffer.alloc(0);
+      socket.on("data", (chunk: Buffer) => {
+        buf = Buffer.concat([buf, chunk]);
+        while (buf.length >= 4) {
+          const len = buf.readUInt32BE(0);
+          if (buf.length < 4 + len) break;
+          frames.push(buf.subarray(4, 4 + len));
+          buf = buf.subarray(4 + len);
+          // Destroy after the first frame to force a drop on the next write.
+          socket.destroy();
+        }
+      });
+    });
+    await new Promise<void>((resolve) => s1.listen(socketPath, resolve));
+
+    const emitter = new Emitter({ socketPath });
+
+    // First emit: connects and delivers.
+    await emitter.emit({ tool: { name: "tool-1" }, decision: "allowed" });
+    await waitFor(() => frames.length >= 1, 2000);
+
+    // Give the peer-reset error time to surface on the emitter's conn.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Close s1 and remove the socket so the next dial will fail.
+    await new Promise<void>((resolve, reject) =>
+      s1.close((e) => (e ? reject(e) : resolve())),
+    );
+    rmSync(socketPath, { force: true });
+
+    // Two fire-and-forget emits with no server — both should drop.
+    // The key property under test: doWrite() captures dropCount at execution
+    // time (serialized), so both drops accumulate correctly rather than the
+    // second emit seeing dropCount=0 and losing the first drop.
+    const p1 = emitter.emit({ tool: { name: "tool-2" }, decision: "allowed" });
+    const p2 = emitter.emit({ tool: { name: "tool-3" }, decision: "allowed" });
+    await p1;
+    await p2;
+
+    // Start a new server and flush — drop_count must be 2.
+    const frames2: Buffer[] = [];
+    const s2 = createServer((socket) => {
+      let buf = Buffer.alloc(0);
+      socket.on("data", (chunk: Buffer) => {
+        buf = Buffer.concat([buf, chunk]);
+        while (buf.length >= 4) {
+          const len = buf.readUInt32BE(0);
+          if (buf.length < 4 + len) break;
+          frames2.push(buf.subarray(4, 4 + len));
+          buf = buf.subarray(4 + len);
+        }
+      });
+    });
+    await new Promise<void>((resolve) => s2.listen(socketPath, resolve));
+
+    await emitter.emit({ tool: { name: "flush" }, decision: "allowed" });
+    await waitFor(() => frames2.length >= 1, 2000);
+
+    const parsed = JSON.parse(frames2[0].toString("utf8")) as Record<string, unknown>;
+    expect(parsed.drop_count).toBe(2);
+
+    emitter.close();
+    await new Promise<void>((resolve, reject) =>
+      s2.close((e) => (e ? reject(e) : resolve())),
+    );
+  }, 10_000);
+
   it("fires warnLog when close() is called with unflushed drops", async () => {
     const socketPath = join(tmpDir, "warn.sock");
     const warnings: Array<{ message: string; attrs: Record<string, string> }> = [];

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -825,6 +825,83 @@ describe("drop_count tracking", () => {
     await close();
   });
 
+  it(
+    "does not accumulate drop_count across a reconnect with prior drops",
+    async () => {
+      // When drops accumulate (daemon down), then a server starts and the
+      // emitter successfully delivers the first frame (flush), dropCount is
+      // zeroed. A subsequent reconnect (emitter re-dials after a peer reset)
+      // must not re-inflate dropCount — the drop_count was already flushed.
+      const socketPath = join(tmpDir, "reconn-drop.sock");
+      const emitter = new Emitter({ socketPath });
+
+      // Cause two drops.
+      await emitter.emit({ tool: { name: "drop-1" }, decision: "allowed" });
+      await emitter.emit({ tool: { name: "drop-2" }, decision: "allowed" });
+
+      // First server: receives one frame (the flush) then forcefully destroys
+      // the connection so the emitter sees a dead conn on the next emit.
+      const frames1: Buffer[] = [];
+      const s1 = createServer((socket) => {
+        let buf = Buffer.alloc(0);
+        socket.on("data", (chunk: Buffer) => {
+          buf = Buffer.concat([buf, chunk]);
+          if (buf.length >= 4) {
+            const len = buf.readUInt32BE(0);
+            if (buf.length >= 4 + len) {
+              frames1.push(buf.subarray(4, 4 + len));
+              socket.destroy();
+            }
+          }
+        });
+      });
+      await new Promise<void>((resolve) => s1.listen(socketPath, resolve));
+
+      // Flush: delivers with drop_count: 2.
+      await emitter.emit({ tool: { name: "flush" }, decision: "allowed" });
+      await waitFor(() => frames1.length >= 1, 2000);
+
+      const flushed = JSON.parse(frames1[0].toString("utf8")) as Record<string, unknown>;
+      expect(flushed.drop_count).toBe(2);
+
+      // Tear down s1, wait for peer reset to propagate, start s2.
+      await new Promise<void>((resolve, reject) =>
+        s1.close((e) => (e ? reject(e) : resolve())),
+      );
+      rmSync(socketPath, { force: true });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const frames2: Buffer[] = [];
+      const s2 = createServer((socket) => {
+        let buf = Buffer.alloc(0);
+        socket.on("data", (chunk: Buffer) => {
+          buf = Buffer.concat([buf, chunk]);
+          while (buf.length >= 4) {
+            const len = buf.readUInt32BE(0);
+            if (buf.length < 4 + len) break;
+            frames2.push(buf.subarray(4, 4 + len));
+            buf = buf.subarray(4 + len);
+          }
+        });
+      });
+      await new Promise<void>((resolve) => s2.listen(socketPath, resolve));
+
+      // Next emit after reconnect: drop_count must be absent — the flush
+      // already zeroed it; the reconnect itself must not re-add to dropCount.
+      await emitter.emit({ tool: { name: "after-reconnect" }, decision: "allowed" });
+      await waitFor(() => frames2.length >= 1, 2000);
+
+      const afterReconn = JSON.parse(frames2[0].toString("utf8")) as Record<string, unknown>;
+      expect(afterReconn.drop_count).toBeUndefined();
+
+      emitter.close();
+      await new Promise<void>((resolve, reject) =>
+        s2.close((e) => (e ? reject(e) : resolve())),
+      );
+    },
+    10_000,
+  );
+
   it("restores drop_count when the oversized-frame guard fires", async () => {
     // An oversized frame is a caller bug — drop_count must survive so it is
     // reported in the next frame that fits.
@@ -853,6 +930,45 @@ describe("drop_count tracking", () => {
     expect(parsed.drop_count).toBe(1);
 
     emitter.close();
+    await close();
+  });
+
+  it("fires warnLog when close() is called with unflushed drops", async () => {
+    const socketPath = join(tmpDir, "warn.sock");
+    const warnings: Array<{ message: string; attrs: Record<string, string> }> = [];
+
+    const emitter = new Emitter({
+      socketPath,
+      warnLog: (message, attrs) => warnings.push({ message, attrs }),
+    });
+
+    // Cause drops with no server listening.
+    await emitter.emit({ tool: { name: "drop-1" }, decision: "allowed" });
+    await emitter.emit({ tool: { name: "drop-2" }, decision: "allowed" });
+
+    // Close without flushing — warnLog must fire.
+    emitter.close();
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toMatch(/unflushed drops/);
+    expect(warnings[0].attrs.drop_count).toBe("2");
+  });
+
+  it("does not fire warnLog when close() is called with no pending drops", async () => {
+    const socketPath = join(tmpDir, "no-warn.sock");
+    const warnings: string[] = [];
+
+    const { close } = await createEchoServer(socketPath);
+    const emitter = new Emitter({
+      socketPath,
+      warnLog: (message) => warnings.push(message),
+    });
+
+    // Successful emit — no drops pending.
+    await emitter.emit({ tool: { name: "bash" }, decision: "allowed" });
+    emitter.close();
+
+    expect(warnings).toHaveLength(0);
     await close();
   });
 });

--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -1032,6 +1032,39 @@ describe("drop_count tracking", () => {
     expect(warnings[0].attrs.drop_count).toBe("2");
   });
 
+  it("fires warnLog from doWrite when close() ran before the dial failed", async () => {
+    // close() checks dropCount at the instant it runs. If doWrite() has already
+    // captured+zeroed dropCount (but not yet failed), close() sees 0 and does
+    // not warn. The new warnLog call in doWrite's failure-restoration path
+    // covers this window: when the dial fails and doWrite restores dropCount,
+    // it also fires warnLog when it detects the emitter is closed.
+    const socketPath = join(tmpDir, "close-race.sock");
+    const warnings: Array<{ message: string; attrs: Record<string, string> }> = [];
+
+    const emitter = new Emitter({
+      socketPath,
+      warnLog: (message, attrs) => warnings.push({ message, attrs }),
+    });
+
+    // Enqueue a write with no server — doWrite will dial and fail.
+    const emitPromise = emitter.emit({ tool: { name: "tool-1" }, decision: "allowed" });
+
+    // Yield one microtask tick so doWrite starts and reaches the dialIfNeeded()
+    // await (at which point it has already zeroed dropCount). This works because
+    // the `.then(() => doWrite(...))` microtask from enqueueWrite was scheduled
+    // before this await, so it runs first.
+    await Promise.resolve();
+
+    // close() now sees dropCount=0 and does not warn. When the dial fails,
+    // doWrite restores dropCount and detects this.closed — it warns then.
+    emitter.close();
+    await emitPromise;
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toMatch(/unflushed drops/);
+    expect(warnings[0].attrs.drop_count).toBe("1");
+  });
+
   it("does not fire warnLog when close() is called with no pending drops", async () => {
     const socketPath = join(tmpDir, "no-warn.sock");
     const warnings: string[] = [];

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -222,12 +222,14 @@ export class Emitter {
    * daemon as drop_count in the next successful frame so the gap appears in
    * the chain as a synthetic events_dropped receipt (ADR-0010).
    *
-   * Read and zeroed atomically in emit() before the first await — safe
-   * because emit() is synchronous up to its enqueueWrite() call and JS is
-   * single-threaded, so no other emit() can interleave between the read and
-   * zero. On transport failure in doWrite(), restored plus one for the frame
-   * itself. On an oversized-frame caller bug, restored without +1 (the frame
-   * was never sent; it is not counted as a drop).
+   * Captured and zeroed inside doWrite() — at the serialized write-queue
+   * execution point — not in emit(). Capturing in emit() races when multiple
+   * fire-and-forget emits are in flight: a later emit can capture dropCount=0
+   * before an earlier queued write fails and increments it, causing the daemon
+   * to never learn about that drop in the immediately-following frame.
+   * Capturing in doWrite() ensures the value always reflects all failures from
+   * writes that completed before this one. On transport failure, restored plus
+   * one for the frame itself.
    */
   private dropCount = 0;
 
@@ -281,12 +283,6 @@ export class Emitter {
       }
     }
 
-    // Capture and zero dropCount before the first await so no concurrent
-    // emit() can observe the same non-zero value. emit() is synchronous up
-    // to enqueueWrite(), and JS is single-threaded, so this is atomic.
-    const capturedDropCount = this.dropCount;
-    this.dropCount = 0;
-
     const wireFrame: WireFrame = {
       v: SUPPORTED_FRAME_VERSION,
       ts_emit: rfc3339Nano(),
@@ -300,21 +296,21 @@ export class Emitter {
       ...(parsedOutput?.ok ? { output: parsedOutput.value } : {}),
       ...(ev.error !== undefined ? { error: ev.error } : {}),
       decision: ev.decision,
-      ...(capturedDropCount > 0 ? { drop_count: capturedDropCount } : {}),
     };
 
-    const body = Buffer.from(JSON.stringify(wireFrame), "utf8");
-    if (body.length > MAX_FRAME_SIZE) {
-      // Restore the captured drop count so it isn't silently lost — it will
-      // be included in the next frame that fits within the size limit.
-      this.dropCount += capturedDropCount;
+    // Preliminary size check without drop_count. doWrite() will inject
+    // drop_count (≤32 bytes) before the final send; a frame that passes here
+    // will not tip over MAX_FRAME_SIZE after that injection.
+    const prelimBody = Buffer.from(JSON.stringify(wireFrame), "utf8");
+    if (prelimBody.length > MAX_FRAME_SIZE) {
       return new Error(
-        `emitter: frame too large: ${body.length} bytes (max ${MAX_FRAME_SIZE})`,
+        `emitter: frame too large: ${prelimBody.length} bytes (max ${MAX_FRAME_SIZE})`,
       );
     }
 
-    // Serialise into the write queue so concurrent calls do not interleave.
-    return this.enqueueWrite(body, capturedDropCount);
+    // Enqueue the frame object. dropCount capture/zero and final serialisation
+    // happen inside doWrite() at the serialized write-queue execution point.
+    return this.enqueueWrite(wireFrame);
   }
 
   /**
@@ -343,12 +339,12 @@ export class Emitter {
   }
 
   /**
-   * Enqueue a serialised write onto the sequential write queue. All calls
-   * run in order; a failed write drops and resets the connection so the
-   * next emit() re-dials transparently.
+   * Enqueue a frame onto the sequential write queue. All calls run in order;
+   * a failed write drops and resets the connection so the next emit()
+   * re-dials transparently.
    */
-  private enqueueWrite(body: Buffer, capturedDropCount: number): Promise<Error | null> {
-    const next = this.writeQueue.then(() => this.doWrite(body, capturedDropCount));
+  private enqueueWrite(frame: WireFrame): Promise<Error | null> {
+    const next = this.writeQueue.then(() => this.doWrite(frame));
     // Keep the queue advancing even if doWrite rejects (it should not, but guard it).
     this.writeQueue = next.then(
       () => {},
@@ -358,22 +354,35 @@ export class Emitter {
   }
 
   /**
-   * doWrite dials if needed, then writes the framed body. Returns null on
-   * success, logs and returns null on transient errors (fire-and-forget).
+   * doWrite captures the current drop count, serialises the frame with it
+   * injected, dials if needed, then writes. Returns null on success and on
+   * transient transport errors (fire-and-forget). On transport failure,
+   * restores capturedDropCount + 1 into dropCount so the next successful
+   * emit() reports the full gap to the daemon.
    *
-   * On transport failure, restores capturedDropCount + 1 into dropCount so
-   * the next successful emit() reports the full gap to the daemon.
+   * dropCount is captured here — inside the serialized write queue — rather
+   * than in emit(). Capturing in emit() races when multiple fire-and-forget
+   * emits are in flight (see dropCount field comment for details).
    *
    * If the write fails on a previously-established connection (e.g. daemon
    * restarted), the dead socket is discarded and one transparent re-dial
    * and re-write is attempted before giving up.
    */
-  private async doWrite(body: Buffer, capturedDropCount: number): Promise<Error | null> {
+  private async doWrite(frame: WireFrame): Promise<Error | null> {
     // Re-check `closed` at execution time: emit() might have validated
     // and enqueued, then close() ran while we were waiting in the queue.
     if (this.closed) {
       return null;
     }
+
+    // Capture and zero dropCount here, at the serialized write-queue
+    // execution point, so the value reflects all prior write failures.
+    const capturedDropCount = this.dropCount;
+    this.dropCount = 0;
+
+    const body = capturedDropCount > 0
+      ? Buffer.from(JSON.stringify({ ...frame, drop_count: capturedDropCount }), "utf8")
+      : Buffer.from(JSON.stringify(frame), "utf8");
 
     const dialErr = await this.dialIfNeeded();
     if (dialErr !== null) {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -404,8 +404,15 @@ export class Emitter {
 
     // close() may have run while we were dialing; in that case dialIfNeeded()
     // still opened a fresh socket — discard it and bail before writing.
+    // capturedDropCount was already zeroed so restore it here (plus one for
+    // this frame) the same way the dial-fail path does.
     if (this.closed) {
       this.dropConn();
+      this.dropCount += capturedDropCount + 1;
+      this.warnLog("agent-receipts emitter closed with unflushed drops", {
+        drop_count: String(this.dropCount),
+        socket: this.socketPath,
+      });
       return null;
     }
 

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -93,6 +93,14 @@ export interface EmitterOptions {
    * Pass `console.debug` or a structured logger to surface drops.
    */
   debugLog?: (message: string, attrs: Record<string, string>) => void;
+  /**
+   * Logger function for warning-level diagnostics. Defaults to no-op.
+   * Wire this to your logger's warn channel — unlike debugLog, warnings from
+   * the emitter indicate conditions the operator should know about (e.g.
+   * pending drops discarded on close). Pass `console.warn` or a structured
+   * logger to make these visible.
+   */
+  warnLog?: (message: string, attrs: Record<string, string>) => void;
 }
 
 /** Wire frame sent to the daemon. Field names must match the daemon's EmitterFrame exactly. */
@@ -194,6 +202,10 @@ export class Emitter {
     message: string,
     attrs: Record<string, string>,
   ) => void;
+  private readonly warnLog: (
+    message: string,
+    attrs: Record<string, string>,
+  ) => void;
 
   private conn: ReturnType<typeof createConnection> | null = null;
   private closed = false;
@@ -213,8 +225,9 @@ export class Emitter {
    * Read and zeroed atomically in emit() before the first await — safe
    * because emit() is synchronous up to its enqueueWrite() call and JS is
    * single-threaded, so no other emit() can interleave between the read and
-   * zero. Restored (plus one for the frame itself) in doWrite() on transport
-   * failure.
+   * zero. On transport failure in doWrite(), restored plus one for the frame
+   * itself. On an oversized-frame caller bug, restored without +1 (the frame
+   * was never sent; it is not counted as a drop).
    */
   private dropCount = 0;
 
@@ -229,6 +242,7 @@ export class Emitter {
     const trimmedSessionId = options.sessionId?.trim();
     this.sessionId = trimmedSessionId ? trimmedSessionId : randomUUID();
     this.debugLog = options.debugLog ?? ((): void => {});
+    this.warnLog = options.warnLog ?? ((): void => {});
   }
 
   /**
@@ -306,12 +320,22 @@ export class Emitter {
   /**
    * Close releases the underlying connection. After close(), subsequent
    * emit() calls return an Error. Safe to call multiple times.
+   *
+   * If drops accumulated since the last successful send and close() is called
+   * before a successful flush, those drops are discarded — the daemon will
+   * never learn about them. warnLog is called to surface this condition.
    */
   close(): void {
     if (this.closed) {
       return;
     }
     this.closed = true;
+    if (this.dropCount > 0) {
+      this.warnLog("agent-receipts emitter closed with unflushed drops", {
+        drop_count: String(this.dropCount),
+        socket: this.socketPath,
+      });
+    }
     if (this.conn !== null) {
       this.conn.destroy();
       this.conn = null;
@@ -380,6 +404,13 @@ export class Emitter {
       if (!retried) {
         this.dropCount += capturedDropCount + 1;
       }
+      // Note: the branch where retried === true (write fails, retry delivers)
+      // is correct — capturedDropCount was already zeroed and the frame was
+      // delivered — but is not directly testable: conn.write() succeeds when
+      // data is queued in the kernel buffer, so write callbacks resolve with
+      // null even when the peer is immediately destroyed, making it
+      // impossible to deterministically trigger a write error followed by a
+      // successful retry via a real Unix socket in unit tests.
     }
     return null;
   }

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -109,6 +109,8 @@ interface WireFrame {
   output?: unknown;
   error?: string;
   decision: string;
+  /** Events dropped since the last successful send. Omitted when zero. */
+  drop_count?: number;
 }
 
 /**
@@ -203,6 +205,18 @@ export class Emitter {
    * (with the same root cause) does not double-log.
    */
   private suppressNextWriteLog = false;
+  /**
+   * Count of events dropped since the last successful send. Flushed to the
+   * daemon as drop_count in the next successful frame so the gap appears in
+   * the chain as a synthetic events_dropped receipt (ADR-0010).
+   *
+   * Read and zeroed atomically in emit() before the first await — safe
+   * because emit() is synchronous up to its enqueueWrite() call and JS is
+   * single-threaded, so no other emit() can interleave between the read and
+   * zero. Restored (plus one for the frame itself) in doWrite() on transport
+   * failure.
+   */
+  private dropCount = 0;
 
   constructor(options: EmitterOptions = {}) {
     const socketPath = options.socketPath ?? defaultSocketPath();
@@ -253,6 +267,12 @@ export class Emitter {
       }
     }
 
+    // Capture and zero dropCount before the first await so no concurrent
+    // emit() can observe the same non-zero value. emit() is synchronous up
+    // to enqueueWrite(), and JS is single-threaded, so this is atomic.
+    const capturedDropCount = this.dropCount;
+    this.dropCount = 0;
+
     const wireFrame: WireFrame = {
       v: SUPPORTED_FRAME_VERSION,
       ts_emit: rfc3339Nano(),
@@ -266,17 +286,21 @@ export class Emitter {
       ...(parsedOutput?.ok ? { output: parsedOutput.value } : {}),
       ...(ev.error !== undefined ? { error: ev.error } : {}),
       decision: ev.decision,
+      ...(capturedDropCount > 0 ? { drop_count: capturedDropCount } : {}),
     };
 
     const body = Buffer.from(JSON.stringify(wireFrame), "utf8");
     if (body.length > MAX_FRAME_SIZE) {
+      // Restore the captured drop count so it isn't silently lost — it will
+      // be included in the next frame that fits within the size limit.
+      this.dropCount += capturedDropCount;
       return new Error(
         `emitter: frame too large: ${body.length} bytes (max ${MAX_FRAME_SIZE})`,
       );
     }
 
     // Serialise into the write queue so concurrent calls do not interleave.
-    return this.enqueueWrite(body);
+    return this.enqueueWrite(body, capturedDropCount);
   }
 
   /**
@@ -299,8 +323,8 @@ export class Emitter {
    * run in order; a failed write drops and resets the connection so the
    * next emit() re-dials transparently.
    */
-  private enqueueWrite(body: Buffer): Promise<Error | null> {
-    const next = this.writeQueue.then(() => this.doWrite(body));
+  private enqueueWrite(body: Buffer, capturedDropCount: number): Promise<Error | null> {
+    const next = this.writeQueue.then(() => this.doWrite(body, capturedDropCount));
     // Keep the queue advancing even if doWrite rejects (it should not, but guard it).
     this.writeQueue = next.then(
       () => {},
@@ -313,11 +337,14 @@ export class Emitter {
    * doWrite dials if needed, then writes the framed body. Returns null on
    * success, logs and returns null on transient errors (fire-and-forget).
    *
+   * On transport failure, restores capturedDropCount + 1 into dropCount so
+   * the next successful emit() reports the full gap to the daemon.
+   *
    * If the write fails on a previously-established connection (e.g. daemon
    * restarted), the dead socket is discarded and one transparent re-dial
    * and re-write is attempted before giving up.
    */
-  private async doWrite(body: Buffer): Promise<Error | null> {
+  private async doWrite(body: Buffer, capturedDropCount: number): Promise<Error | null> {
     // Re-check `closed` at execution time: emit() might have validated
     // and enqueued, then close() ran while we were waiting in the queue.
     if (this.closed) {
@@ -327,6 +354,9 @@ export class Emitter {
     const dialErr = await this.dialIfNeeded();
     if (dialErr !== null) {
       this.logDrop("dial", dialErr);
+      // Restore captured drops plus one for this frame, so the next
+      // successful emit() reports the full gap.
+      this.dropCount += capturedDropCount + 1;
       return null;
     }
 
@@ -346,31 +376,33 @@ export class Emitter {
       }
       this.suppressNextWriteLog = false;
       this.dropConn();
-      await this.retryWrite(body);
+      const retried = await this.retryWrite(body);
+      if (!retried) {
+        this.dropCount += capturedDropCount + 1;
+      }
     }
     return null;
   }
 
   /**
-   * retryWrite re-dials and writes once. On failure the connection is
-   * dropped and the error is logged. Separated into its own method so that
-   * TypeScript's narrowing of `this.conn` from `dropConn()` does not flow
-   * into this scope.
+   * retryWrite re-dials and writes once. Returns true on success, false on
+   * any transport failure. Separated into its own method so that TypeScript's
+   * narrowing of `this.conn` from `dropConn()` does not flow into this scope.
    */
-  private async retryWrite(body: Buffer): Promise<void> {
+  private async retryWrite(body: Buffer): Promise<boolean> {
     // close() may have run while we awaited the failed first write — bail
     // out so we don't open a fresh connection on a closed emitter.
     if (this.closed) {
-      return;
+      return false;
     }
     const redialErr = await this.dialIfNeeded();
     if (redialErr !== null) {
       this.logDrop("dial", redialErr);
-      return;
+      return false;
     }
     if (this.closed) {
       this.dropConn();
-      return;
+      return false;
     }
     const retryErr = await this.writeFrame(body);
     if (retryErr !== null) {
@@ -379,7 +411,9 @@ export class Emitter {
       }
       this.suppressNextWriteLog = false;
       this.dropConn();
+      return false;
     }
+    return true;
   }
 
   /** Destroy and null the current connection (if any). */

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -298,18 +298,10 @@ export class Emitter {
       decision: ev.decision,
     };
 
-    // Preliminary size check without drop_count. doWrite() will inject
-    // drop_count (≤32 bytes) before the final send; a frame that passes here
-    // will not tip over MAX_FRAME_SIZE after that injection.
-    const prelimBody = Buffer.from(JSON.stringify(wireFrame), "utf8");
-    if (prelimBody.length > MAX_FRAME_SIZE) {
-      return new Error(
-        `emitter: frame too large: ${prelimBody.length} bytes (max ${MAX_FRAME_SIZE})`,
-      );
-    }
-
-    // Enqueue the frame object. dropCount capture/zero and final serialisation
-    // happen inside doWrite() at the serialized write-queue execution point.
+    // Enqueue the frame object. dropCount capture/zero, drop_count injection,
+    // serialisation, and the size check all happen inside doWrite() at the
+    // serialized write-queue execution point — after drop_count is injected —
+    // so the size limit is enforced on the actual bytes that will be sent.
     return this.enqueueWrite(wireFrame);
   }
 
@@ -384,12 +376,29 @@ export class Emitter {
       ? Buffer.from(JSON.stringify({ ...frame, drop_count: capturedDropCount }), "utf8")
       : Buffer.from(JSON.stringify(frame), "utf8");
 
+    // Size check after drop_count injection — the limit applies to the actual
+    // bytes that will be sent. Restore capturedDropCount (no +1; the frame was
+    // never sent) so it appears in the next successfully delivered frame.
+    if (body.length > MAX_FRAME_SIZE) {
+      this.dropCount += capturedDropCount;
+      return new Error(
+        `emitter: frame too large: ${body.length} bytes (max ${MAX_FRAME_SIZE})`,
+      );
+    }
+
     const dialErr = await this.dialIfNeeded();
     if (dialErr !== null) {
       this.logDrop("dial", dialErr);
       // Restore captured drops plus one for this frame, so the next
-      // successful emit() reports the full gap.
+      // successful emit() reports the full gap. If the emitter is already
+      // closed, no future emit() will flush — warn immediately.
       this.dropCount += capturedDropCount + 1;
+      if (this.closed) {
+        this.warnLog("agent-receipts emitter closed with unflushed drops", {
+          drop_count: String(this.dropCount),
+          socket: this.socketPath,
+        });
+      }
       return null;
     }
 
@@ -411,7 +420,15 @@ export class Emitter {
       this.dropConn();
       const retried = await this.retryWrite(body);
       if (!retried) {
+        // Restore captured drops plus one for this frame. If the emitter is
+        // already closed, no future emit() will flush — warn immediately.
         this.dropCount += capturedDropCount + 1;
+        if (this.closed) {
+          this.warnLog("agent-receipts emitter closed with unflushed drops", {
+            drop_count: String(this.dropCount),
+            socket: this.socketPath,
+          });
+        }
       }
       // Note: the branch where retried === true (write fails, retry delivers)
       // is correct — capturedDropCount was already zeroed and the frame was


### PR DESCRIPTION
## Summary

- Adds `drop_count` tracking to `Emitter` in `src/emitter.ts`, closing the last gap between the openclaw emitter and the full daemon wire format (`EmitterFrame` in `daemon/internal/pipeline/build.go`)
- When transport fails (dial timeout, broken connection, failed retry), a per-emitter counter increments instead of the event disappearing silently
- The counter is captured and zeroed inside `doWrite()` — at the serialized write-queue execution point — so it always reflects all failures from writes that completed before this one. Capturing in `emit()` would race when multiple fire-and-forget emits are in flight: a later emit can observe `dropCount=0` before an earlier queued write fails and increments it
- The counter is written into the wire frame as `drop_count` when non-zero; the daemon inserts a synthetic `events_dropped` receipt before the next live receipt, making the gap visible in the chain (ADR-0010)
- The size check happens in `doWrite()` after `drop_count` injection — ensuring the limit is enforced on the actual bytes sent, not a preliminary estimate
- On transport failure, `dropCount` is restored (plus one for the dropped frame itself). If the emitter is already closed when the failure is detected, `warnLog` fires immediately since no future `emit()` will flush the count
- Adds `warnLog` option to `EmitterOptions` (separate warn-level channel, distinct from `debugLog`). `close()` warns when `dropCount > 0` at shutdown time; `doWrite()`'s failure-restoration paths also warn when they detect the emitter is already closed

Part of #139 (Flavor B migration, Stage 1). Stage 2 (cut over local store → daemon DB) depends on `openStoreReadOnly` landing in `@agnt-rcpt/sdk-ts` first.

Tracking issue for pre-existing spurious drop log on retry success: #141.

## Test plan

- [ ] `pnpm test` passes (225 tests, 2 skipped — daemon binary absent in CI)
- [ ] `pnpm typecheck` passes
- [ ] `drop_count tracking` describe block (9 tests) covers: omit when zero, flush after failures, reset after flush, accumulate across failures, oversized-frame guard, concurrent-emit race regression, warnLog on close with drops, warnLog silent when no drops, warnLog from doWrite when close races the dial
