### PR TITLE
docs: ship CHANGELOG.md in npm tarball and document contributor workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@ Motivation — what problem does this solve?
 - [ ] No real keys or secrets in the diff
 - [ ] Taxonomy changes include tests in `src/classify.test.ts`
 - [ ] AGENTS.md updated (if project structure changed)
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]` (for user-visible changes)
 
 > [!TIP]
 > Request a Copilot review for automated checks against project conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,10 +102,11 @@ Before marking work as complete:
 
 1. Confirm all touched tests and linters pass.
 2. Re-read your full diff — check for mistakes, consistency, and completeness.
-3. Summarise changes with file and line references.
-4. Mention any opportunistic papercut fixes made along the way.
-5. Call out TODOs, follow-up work, or uncertainties.
-6. If opening a PR, verify the description accurately reflects the changes.
+3. Add an entry under `## [Unreleased]` in `CHANGELOG.md` for user-visible changes (skip for internal-only refactors, CI tweaks, or test-only edits).
+4. Summarise changes with file and line references.
+5. Mention any opportunistic papercut fixes made along the way.
+6. Call out TODOs, follow-up work, or uncertainties.
+7. If opening a PR, verify the description accurately reflects the changes.
 
 ## Agent safety rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `CHANGELOG.md` is now shipped in the npm tarball (added to `package.json` `files`). `CONTRIBUTING.md` and `AGENTS.md` document the contributor workflow: add an entry under `## [Unreleased]` for user-visible changes; the release script promotes it to a versioned heading ([#95](https://github.com/agent-receipts/openclaw/issues/95)).
+
 ### Changed (breaking)
 
 - **Daemon is now required (ADR-0010 Flavor B).** The plugin no longer holds keys, chain state, or a local SQLite store. Every tool call is forwarded to the local agent-receipts daemon over AF_UNIX; the daemon signs, hash-links, and stores receipts. If the socket is unreachable at startup, a warning is logged. Per-frame delivery is fire-and-forget — no receipts are recorded while the daemon is absent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- `CHANGELOG.md` is now shipped in the npm tarball (added to `package.json` `files`). `CONTRIBUTING.md` and `AGENTS.md` document the contributor workflow: add an entry under `## [Unreleased]` for user-visible changes; the release script promotes it to a versioned heading ([#95](https://github.com/agent-receipts/openclaw/issues/95)).
-
 ### Changed (breaking)
 
 - **Daemon is now required (ADR-0010 Flavor B).** The plugin no longer holds keys, chain state, or a local SQLite store. Every tool call is forwarded to the local agent-receipts daemon over AF_UNIX; the daemon signs, hash-links, and stores receipts. If the socket is unreachable at startup, a warning is logged. Per-frame delivery is fire-and-forget — no receipts are recorded while the daemon is absent.
@@ -28,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `CHANGELOG.md` is now shipped in the npm tarball (added to `package.json` `files`). `CONTRIBUTING.md` and `AGENTS.md` document the contributor workflow: add an entry under `## [Unreleased]` for user-visible changes; the release script promotes it to a versioned heading ([#95](https://github.com/agent-receipts/openclaw/issues/95)).
 - `src/daemon-store.ts` — opens the daemon's SQLite receipt database read-only via `DatabaseSync` URI mode.
 - `DaemonStoreReader` type — narrow interface (`query`, `stats`, `close`, `getChain`) limits callers to read-only operations.
 - `verifyDaemonChain` helper — centralises the one unsafe cast needed to bridge `DaemonStoreReader` with `verifyStoredChain`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,14 @@ lefthook install
 
 See the [convco installation docs](https://convco.github.io/check/installation/) for all options.
 
+## Changelog
+
+User-visible changes (features, fixes, breaking changes, deprecations) belong in [`CHANGELOG.md`](CHANGELOG.md). Add an entry under the `## [Unreleased]` heading as part of your PR, using the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) section conventions (`Added`, `Changed`, `Changed (breaking)`, `Deprecated`, `Removed`, `Fixed`, `Security`). Link the issue or PR number when there is one.
+
+Internal-only changes (refactors with no observable behavior change, CI tweaks, test-only edits) do not need a changelog entry.
+
+The release script promotes `## [Unreleased]` to a versioned heading and rewrites the reference links at the bottom of the file, so contributors only need to add the entry — versioning is automatic.
+
 ## Taxonomy Contributions
 
 Adding mappings for new OpenClaw tools is a great way to contribute. Edit `taxonomy.json` and add corresponding tests in `src/classify.test.ts`.
@@ -126,6 +134,7 @@ Before opening a PR, verify:
 - [ ] No real keys or secrets in the diff — use test fixtures only
 - [ ] Taxonomy changes include corresponding tests in `src/classify.test.ts`
 - [ ] AGENTS.md updated if you changed project structure
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]` for user-visible changes
 - [ ] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/) format
 
 ## License

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ See the [convco installation docs](https://convco.github.io/check/installation/)
 
 ## Changelog
 
-User-visible changes (features, fixes, breaking changes, deprecations) belong in [`CHANGELOG.md`](CHANGELOG.md). Add an entry under the `## [Unreleased]` heading as part of your PR, using the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) section conventions (`Added`, `Changed`, `Changed (breaking)`, `Deprecated`, `Removed`, `Fixed`, `Security`). Link the issue or PR number when there is one.
+User-visible changes (features, fixes, breaking changes, deprecations) belong in [`CHANGELOG.md`](CHANGELOG.md). Add an entry under the `## [Unreleased]` heading as part of your PR. This repo extends [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with a custom `Changed (breaking)` section to separate breaking changes from regular improvements; use standard Keep a Changelog sections (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`) plus `Changed (breaking)`. Link the issue or PR number when there is one.
 
 Internal-only changes (refactors with no observable behavior change, CI tweaks, test-only edits) do not need a changelog entry.
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "files": [
     "dist",
     "taxonomy.json",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "CHANGELOG.md"
   ],
   "engines": {
     "node": ">=22.11.0"


### PR DESCRIPTION
Closes #95.

## What

- Add `CHANGELOG.md` to `package.json` `files` so it ships in the published npm tarball (with a `files` array set, npm does **not** auto-include CHANGELOG — verified before/after via `npm pack --dry-run`).
- New "Changelog" section in `CONTRIBUTING.md` explaining when and how contributors add entries under `## [Unreleased]`, with Keep-a-Changelog section names.
- Add `CHANGELOG.md` to the pre-submit checklists in `CONTRIBUTING.md`, `AGENTS.md` ("Completing work"), and `.github/pull_request_template.md`.
- Eat my own dogfood: added an `## [Unreleased]` entry for this change.

## Why

`CHANGELOG.md` already existed in the repo (seeded earlier with all released versions), but two acceptance criteria from #95 weren't met:

1. It wasn't shipping in the npm tarball — `npm pack --dry-run` showed only 5 files: `LICENSE`, `README.md`, `openclaw.plugin.json`, `package.json`, `taxonomy.json`. Consumers installing from npm couldn't read the changelog without visiting GitHub.
2. Contributor docs didn't tell people to update `## [Unreleased]` as part of their PR — only the release-process section mentioned the file, framed at release-cut time.

The existing `scripts/release.sh` already promotes `## [Unreleased]` to a versioned heading and rewrites reference links, so the contributor workflow is just "add a bullet under Unreleased".

## Verification

```
$ npm pack --dry-run --json | jq -r '.[0].files[].path'
CHANGELOG.md     ← now included
LICENSE
README.md
openclaw.plugin.json
package.json
taxonomy.json
```

`npx tsc --noEmit` clean; `npx vitest run` → 191 passed, 2 skipped.

## Checklist

- [x] `pnpm test` passes (via `npx vitest run` — pnpm strict-mode blocked on unrelated ignored-builds prompt)
- [x] `pnpm run typecheck` passes (via `npx tsc --noEmit`)
- [x] No real keys or secrets in the diff
- [x] Taxonomy changes include tests in `src/classify.test.ts` (n/a)
- [x] AGENTS.md updated (added CHANGELOG step to "Completing work")
- [x] `CHANGELOG.md` updated under `## [Unreleased]`