### PR TITLE
chore(deps): bump @agnt-rcpt/sdk-ts to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@agnt-rcpt/sdk-ts": "^0.8.0",
+    "@agnt-rcpt/sdk-ts": "^0.9.0",
     "@sinclair/typebox": "0.34.49"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@agnt-rcpt/sdk-ts':
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.9.0
+        version: 0.9.0
       '@sinclair/typebox':
         specifier: 0.34.49
         version: 0.34.49
@@ -38,8 +38,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@agnt-rcpt/sdk-ts@0.8.0':
-    resolution: {integrity: sha512-bpwmioSgYQeGL2H6oOns7MjnDdbqwiaMrs8u3OfJN08Jc5Wkn/I5ZTQdBd35sXrZy1am/NQpk+PZpmRKyfRkzA==}
+  '@agnt-rcpt/sdk-ts@0.9.0':
+    resolution: {integrity: sha512-ZmvJbT4/fqNhdMQvEZYBq488zHxT1n0IngCcN4Il+l8ZN7FC/C0Yp120SR2RPwnFDQcFvFtLpfELDUrRnQe4ow==}
     engines: {node: '>=22.11.0'}
 
   '@anthropic-ai/sdk@0.91.1':
@@ -403,6 +403,14 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@hpke/common@1.10.1':
+    resolution: {integrity: sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==}
+    engines: {node: '>=16.0.0'}
+
+  '@hpke/core@1.9.0':
+    resolution: {integrity: sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==}
+    engines: {node: '>=16.0.0'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2376,8 +2384,9 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@agnt-rcpt/sdk-ts@0.8.0':
+  '@agnt-rcpt/sdk-ts@0.9.0':
     dependencies:
+      '@hpke/core': 1.9.0
       zod: 4.4.3
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
@@ -2834,6 +2843,12 @@ snapshots:
   '@hono/node-server@1.19.14(hono@4.12.19)':
     dependencies:
       hono: 4.12.19
+
+  '@hpke/common@1.10.1': {}
+
+  '@hpke/core@1.9.0':
+    dependencies:
+      '@hpke/common': 1.10.1
 
   '@img/colour@1.1.0':
     optional: true


### PR DESCRIPTION
## Summary

- Bumps `@agnt-rcpt/sdk-ts` from `^0.8.0` to `^0.9.0` (stable graduation from the 0.9.0 alpha series).
- Lockfile updated; transitively pulls in `@hpke/core@1.9.0` and `@hpke/common@1.10.1` as new deps of `@agnt-rcpt/sdk-ts@0.9.0`.
- `tsc -p tsconfig.build.json` and `tsc --noEmit` both clean.
- `vitest run`: **191 passed, 2 skipped** (7 test files) — no regressions vs the 0.8.0 baseline.

## Why

Phase 6 of the `agent-receipts/ar` v0.3.0 release sequence (`agent-receipts/ar#280`); same surface previously validated end-to-end against openclaw in `agent-receipts/ar#519`.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm build` (`tsc -p tsconfig.build.json`) clean
- [x] `pnpm test` (vitest): 191 passed, 2 skipped
- [ ] No real keys or secrets in the diff
- [ ] AGENTS.md updated (if project structure changed) — N/A, dep bump only