### PR TITLE
chore(release): bump to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-22
+
 ### Changed (breaking)
 
 - **Daemon is now required (ADR-0010 Flavor B).** The plugin no longer holds keys, chain state, or a local SQLite store. Every tool call is forwarded to the local agent-receipts daemon over AF_UNIX; the daemon signs, hash-links, and stores receipts. If the socket is unreachable at startup, a warning is logged. Per-frame delivery is fire-and-forget — no receipts are recorded while the daemon is absent.
@@ -15,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ar_verify_chain` reads the daemon DB and public key from disk.** Chain auto-discovery picks the first chain found; pass `chain_id` explicitly in multi-chain stores.
 - **Issuer DID.** Historical Flavor A chains were signed by the plugin under `did:openclaw:<agentId>`. New chains are signed by the daemon using its own identity. The discontinuity is expected; see the upgrade guide in the README.
 - **`parameterDisclosure` plugin config is now a no-op** and emits a startup warning. Use the daemon's `--parameter-disclosure` flag instead.
+
+### Changed
+
+- Bump `@agnt-rcpt/sdk-ts` to `^0.9.0` ([#146](https://github.com/agent-receipts/openclaw/pull/146)), which carries the v0.3.0 envelope-shape `parameters_disclosure` (per [agent-receipts/ar#280](https://github.com/agent-receipts/ar/issues/280) and validated end-to-end in [agent-receipts/ar#519](https://github.com/agent-receipts/ar/issues/519) §5). No openclaw API breakage — the new envelope type is only visible to callers that reach into `Action.parameters_disclosure` directly.
 
 ### Removed
 
@@ -30,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `verifyDaemonChain` helper — centralises the one unsafe cast needed to bridge `DaemonStoreReader` with `verifyStoredChain`.
 - Startup warning when the daemon socket is unreachable, with install instructions.
 - Caller-bug errors returned by `emitter.emit()` (e.g. invalid event fields, closed emitter) are now logged at warn level via the plugin logger. Transport-level drops (daemon unreachable mid-session) remain fire-and-forget and are not individually logged.
+
+### Known issues
+
+- Transitive `@hpke/core` dependency exposure is being addressed upstream — tracked in [agent-receipts/ar#473](https://github.com/agent-receipts/ar/issues/473). No action required from openclaw consumers.
 
 ## [0.8.0] - 2026-05-15
 
@@ -208,7 +218,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security hardening: key file permissions, input validation, pending-map memory
   leak prevention (#22).
 
-[Unreleased]: https://github.com/agent-receipts/openclaw/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/agent-receipts/openclaw/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/agent-receipts/openclaw/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/agent-receipts/openclaw/compare/v0.6.0...v0.8.0
 [0.6.0]: https://github.com/agent-receipts/openclaw/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/agent-receipts/openclaw/compare/v0.4.0...v0.5.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What

Bump `@agnt-rcpt/openclaw` from `0.8.0` to `0.9.0` so the package can be tagged and published to npm. Promotes the existing `[Unreleased]` section in `CHANGELOG.md` to `[0.9.0] - 2026-05-22` and appends a note about the `@agnt-rcpt/sdk-ts` dep bump that landed on main in #146.

No source changes — `release.sh` (and `publish.yml`, which fires on `release: published`) requires `package.json.version` to match the tag, so this prep PR exists purely to align the manifest before tagging `v0.9.0`.

## Why

Part of the [v0.3.0 release plan for agent-receipts/ar](https://github.com/agent-receipts/ar/issues/280):

- sdk-ts `0.9.0` (the v0.3.0 envelope-shape `parameters_disclosure`) is already wired up on `main` via #146.
- Cross-SDK envelope-shape validation passed end-to-end in [agent-receipts/ar#519](https://github.com/agent-receipts/ar/issues/519) §5.
- Now the openclaw package needs its own version bump so the consumer-facing release can ship.

No openclaw API breakage — the new envelope type is only visible to callers that reach into `Action.parameters_disclosure` directly. The transitive `@hpke/core` dep concern is noted in the changelog and tracked upstream in [agent-receipts/ar#473](https://github.com/agent-receipts/ar/issues/473).

## Files changed

- `package.json` — version `0.8.0` → `0.9.0`
- `CHANGELOG.md` — promote `[Unreleased]` to `[0.9.0]`, add sdk-ts bump note + known-issues entry, update reference links

## Checklist

- [x] `pnpm test` passes — 191 passed, 2 skipped, 0 failed (ran via `node node_modules/vitest/vitest.mjs run`)
- [x] `tsc -p tsconfig.build.json` passes clean
- [x] No real keys or secrets in the diff
- [x] No taxonomy changes
- [x] AGENTS.md unchanged (no project structure changes)
- [x] `CHANGELOG.md` updated — `[Unreleased]` promoted to `[0.9.0]`

## Test plan

- [ ] CI typecheck + test workflows pass
- [ ] After merge: `scripts/release.sh 0.9.0` (or manual `git tag v0.9.0 && gh release create v0.9.0 --generate-notes`) — should be a no-op for CHANGELOG/package.json since this PR already aligned them; expect the workflow to publish to npm

## Notes

- Used a fresh clone at `/tmp/openclaw-v0.9.0-bump` (per release-plan guidance to avoid stale worktree state from before #146 merged).
- `pnpm install` left `pnpm-lock.yaml` unchanged — only this package's own version moved, no transitive resolution change.
- `pnpm install` emitted an `ERR_PNPM_IGNORED_BUILDS` warning for `@google/genai`, `esbuild`, `koffi`, `openclaw`, `protobufjs`, `sharp`, `tree-sitter-bash`; pre-existing, not introduced by this PR.