### PR TITLE
chore(release): bump to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnt-rcpt/openclaw",
-  "version": "0.9.1-rc.2",
+  "version": "0.9.1",
   "description": "Cryptographically signed audit trail for OpenClaw agent actions via Agent Receipts",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Release v0.9.1 — socket emission fixes for issue #148.

See PR #149 for details on the fixes.